### PR TITLE
Improve error message for failed address resolution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 
 ### 2.0b3 (unreleased)
 
-- Nothing changed yet.
+- Improve error message in case of a DNS error during address resolution
 
 
 ### 2.0b2 (2019-10-15)

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The project is licensed under the 2-clause BSD license.
 
 ### 2.0b3 (unreleased)
 
-- Nothing changed yet.
+- Improve error message in case of a DNS error during address resolution
 
 
 ### 2.0b2 (2019-10-15)

--- a/src/batou/tests/test_utils.py
+++ b/src/batou/tests/test_utils.py
@@ -90,7 +90,9 @@ def test_address_v6_only():
 def test_address_fails_when_name_cannot_be_looked_up_at_all():
     with pytest.raises(socket.gaierror) as f:
         Address("does-not-exist.example.com:1234")
-    assert 'No v4 or v6 address for does-not-exist.example.com' == str(f.value)
+    assert (
+        "No v4 or v6 address for "
+        "'does-not-exist.example.com'." == str(f.value))
 
 
 def test_address_format_with_port():

--- a/src/batou/utils.py
+++ b/src/batou/utils.py
@@ -167,7 +167,8 @@ class Address(object):
             self.listen_v6 = NetLoc(v6_address, str(port))
 
         if not self.listen and not self.listen_v6:
-            raise socket.gaierror("No v4 or v6 address for %s" % connect)
+            raise socket.gaierror(
+                "No v4 or v6 address for '{}'.".format(connect))
 
     def __lt__(self, other):
         if isinstance(other, Address):


### PR DESCRIPTION
When creating an Address-object while passing a FQDN with quotes to, the DNS resolution is failing 
The error message was kind of obfuscating the reason (wrong quotes) for.