### PR TITLE
Rename header to match subcommand.

### DIFF
--- a/doc/source/cli/index.txt
+++ b/doc/source/cli/index.txt
@@ -70,8 +70,8 @@ batou secrets edit
       --editor EDITOR, -e EDITOR
                             Invoke EDITOR to edit (default: $EDITOR or vi)
 
-batou secrets overview
-----------------------
+batou secrets summary
+---------------------
 
 Show an overview of which users have access to what encrypted secrets.
 


### PR DESCRIPTION
The previous header "batou secrets overview" was misleading, as this
command does not exist and leads to an "invalid choice" error when
executed.

Now, the header has the same name as the subcommand - just as all the
other examples in the documentation.

modified:   doc/source/cli/index.txt