### PR TITLE
Fix virtualenv creation on Python 2.7.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@
 set -ex
 
 rm -rf .Python bin lib include
-virtualenv --python python .
+virtualenv --python=python2.7 --no-download .
 bin/pip install setuptools==40.0.0
 bin/pip install zc.buildout==2.13.1
 ./bin/buildout bootstrap

--- a/examples/django/batou
+++ b/examples/django/batou
@@ -37,7 +37,7 @@ def install_venv():
     for fast in ['-F', '--fast']:
         while fast in sys.argv:
             sys.argv.remove(fast)
-    cmd('virtualenv --python=python2.7 .batou')
+    cmd('virtualenv --python=python2.7 --no-download .batou')
 
 
 def install_pip():

--- a/examples/errors/batou
+++ b/examples/errors/batou
@@ -37,7 +37,7 @@ def install_venv():
     for fast in ['-F', '--fast']:
         while fast in sys.argv:
             sys.argv.remove(fast)
-    cmd('virtualenv --python=python2.7 .batou')
+    cmd('virtualenv --python=python2.7 --no-download .batou')
 
 
 def install_pip():

--- a/examples/ignores/batou
+++ b/examples/ignores/batou
@@ -37,7 +37,7 @@ def install_venv():
     for fast in ['-F', '--fast']:
         while fast in sys.argv:
             sys.argv.remove(fast)
-    cmd('virtualenv --python=python2.7 .batou')
+    cmd('virtualenv --python=python2.7 --no-download .batou')
 
 
 def install_pip():

--- a/examples/largetempl/batou
+++ b/examples/largetempl/batou
@@ -37,7 +37,7 @@ def install_venv():
     for fast in ['-F', '--fast']:
         while fast in sys.argv:
             sys.argv.remove(fast)
-    cmd('virtualenv --python=python2.7 .batou')
+    cmd('virtualenv --python=python2.7 --no-download .batou')
 
 
 def install_pip():

--- a/examples/package/batou
+++ b/examples/package/batou
@@ -37,7 +37,7 @@ def install_venv():
     for fast in ['-F', '--fast']:
         while fast in sys.argv:
             sys.argv.remove(fast)
-    cmd('virtualenv --python=python2.7 .batou')
+    cmd('virtualenv --python=python2.7 --no-download .batou')
 
 
 def install_pip():

--- a/examples/tutorial-component/batou
+++ b/examples/tutorial-component/batou
@@ -37,7 +37,7 @@ def install_venv():
     for fast in ['-F', '--fast']:
         while fast in sys.argv:
             sys.argv.remove(fast)
-    cmd('virtualenv --python=python2.7 .batou')
+    cmd('virtualenv --python=python2.7 --no-download .batou')
 
 
 def install_pip():

--- a/examples/tutorial-helloworld/batou
+++ b/examples/tutorial-helloworld/batou
@@ -37,7 +37,7 @@ def install_venv():
     for fast in ['-F', '--fast']:
         while fast in sys.argv:
             sys.argv.remove(fast)
-    cmd('virtualenv --python=python2.7 .batou')
+    cmd('virtualenv --python=python2.7 --no-download .batou')
 
 
 def install_pip():

--- a/examples/tutorial-secrets/batou
+++ b/examples/tutorial-secrets/batou
@@ -37,7 +37,7 @@ def install_venv():
     for fast in ['-F', '--fast']:
         while fast in sys.argv:
             sys.argv.remove(fast)
-    cmd('virtualenv --python=python2.7 .batou')
+    cmd('virtualenv --python=python2.7 --no-download .batou')
 
 
 def install_pip():

--- a/examples/vagrant-multi/batou
+++ b/examples/vagrant-multi/batou
@@ -37,7 +37,7 @@ def install_venv():
     for fast in ['-F', '--fast']:
         while fast in sys.argv:
             sys.argv.remove(fast)
-    cmd('virtualenv --python=python2.7 .batou')
+    cmd('virtualenv --python=python2.7 --no-download .batou')
 
 
 def install_pip():

--- a/examples/vagrant/batou
+++ b/examples/vagrant/batou
@@ -37,7 +37,7 @@ def install_venv():
     for fast in ['-F', '--fast']:
         while fast in sys.argv:
             sys.argv.remove(fast)
-    cmd('virtualenv --python=python2.7 .batou')
+    cmd('virtualenv --python=python2.7 --no-download .batou')
 
 
 def install_pip():

--- a/examples/venvs/batou
+++ b/examples/venvs/batou
@@ -34,7 +34,7 @@ def install_venv():
     # Discover the right venv cmd. Or let batou figure that out later in a
     # second phase?
     # XXX Give advice if virtualenv isn't there.
-    cmd('virtualenv --python=python2.7 .batou')
+    cmd('virtualenv --python=python2.7 --no-download .batou')
 
 
 def install_pip():

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         'Jinja2',
         'requests',
-        'setuptools',
+        'setuptools < 45',
         'execnet',
         'pyyaml',
         'py'

--- a/src/batou/bootstrap-template
+++ b/src/batou/bootstrap-template
@@ -37,7 +37,7 @@ def install_venv():
     for fast in ['-F', '--fast']:
         while fast in sys.argv:
             sys.argv.remove(fast)
-    cmd('virtualenv --python=python2.7 .batou')
+    cmd('virtualenv --python=python2.7 --no-download .batou')
 
 
 def install_pip():

--- a/src/batou/lib/python.py
+++ b/src/batou/lib/python.py
@@ -124,7 +124,7 @@ class VirtualEnvPy2_7(VirtualEnvPyBase):
 
     venv_version = '16.1.0'
     venv_checksum = 'md5:ad6d2ebd6885b3a2b4ff2030ce532a2f'
-    venv_options = ()
+    venv_options = ('--no-download', )
 
     install_options = ()
 


### PR DESCRIPTION
We have to forbid downloading setuptools from PyPI but force to use the
version bundeled with virtualenv.

Additionally we need to force a setuptools version < 45 so `pip`
installs a Python 2.7 compatible version later on.

Fixes #25.