### PR TITLE
Add ability to disable supervisor programs.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ Changelog
 1.12.6 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add ability to disable supervisor programs.
 
 
 1.12.5 (2020-03-27)

--- a/src/batou/lib/tests/test_supervisor.py
+++ b/src/batou/lib/tests/test_supervisor.py
@@ -27,6 +27,16 @@ def test_waits_for_start(root, supervisor):
 
 
 @pytest.mark.slow
+def test_does_not_start_disabled_program(root, supervisor):
+    root.component += batou.lib.supervisor.Program(
+        'foo', command_absolute=False,
+        command='bash', args='-c "sleep 1; touch %s/foo; sleep 3600"' % (
+            root.workdir), options=dict(startsecs=2), enable=False)
+    root.component.deploy()
+    assert not os.path.exists('%s/foo' % root.workdir)
+
+
+@pytest.mark.slow
 def test_program_does_not_start_within_startsecs_raises(root, supervisor):
     root.component += batou.lib.supervisor.Program(
         'foo', command_absolute=False, command='true',


### PR DESCRIPTION
I currently have the need to disable a supervisor program which was created before. It will be needed in future so I do not want to delete it. (I do not know of batou tooling to delete supervisor programs, so I'd like so avoid the hassle to do it manually.)

This PR is currently aimed against 1.x as I need it there. After it being accepted I can create another PR against `master`. 