### PR TITLE
Add ability to disable supervisor programs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 2.0b6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add ability to disable supervisor programs.
 
 
 2.0b5 (2020-04-15)

--- a/src/batou/lib/tests/test_supervisor.py
+++ b/src/batou/lib/tests/test_supervisor.py
@@ -27,6 +27,16 @@ def test_waits_for_start(root, supervisor):
 
 
 @pytest.mark.slow
+def test_does_not_start_disabled_program(root, supervisor):
+    root.component += batou.lib.supervisor.Program(
+        'foo', command_absolute=False,
+        command='bash', args='-c "sleep 1; touch %s/foo; sleep 3600"' % (
+            root.workdir), options=dict(startsecs=2), enable=False)
+    root.component.deploy()
+    assert not os.path.exists('%s/foo' % root.workdir)
+
+
+@pytest.mark.slow
 def test_program_does_not_start_within_startsecs_raises(root, supervisor):
     root.component += batou.lib.supervisor.Program(
         'foo', command_absolute=False, command='true',


### PR DESCRIPTION
This is the port of #33 to `master`.

The test failures seem to be unrelated, see #37.