### PR TITLE
Fix "is supervisor program running" check if it is stopped or exited

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,9 @@
 - Improve verify() of archive handler so we predict a change if
   something goes wrong (like not having the archive downloaded yet)
 
+- Fix "is supervisor program running" check if it is stopped or exited
+
+
 2.0b12 (2020-05-13)
 -------------------
 

--- a/src/batou/lib/supervisor.py
+++ b/src/batou/lib/supervisor.py
@@ -105,7 +105,8 @@ redirect_stderr = true
                 'Program "{}" did not start up'.format(self.name))
 
     def is_running(self):
-        out, err = self.ctl('status {}'.format(self.name))
+        out, err = self.ctl(
+            'status {}'.format(self.name), ignore_returncode=True)
         return 'RUNNING' in out
 
     # Keep track whether

--- a/src/batou/lib/tests/test_supervisor.py
+++ b/src/batou/lib/tests/test_supervisor.py
@@ -46,6 +46,19 @@ def test_program_does_not_start_within_startsecs_raises(root, supervisor):
 
 
 @pytest.mark.slow
+def test_starts_stopped_program(root, supervisor):
+    root.component += batou.lib.supervisor.Program(
+        'foo', command_absolute=False,
+        command='bash', args='-c "sleep 3600"', options=dict(startsecs=2))
+    root.component.deploy()
+    supervisor.cmd(
+        '{}/bin/supervisorctl stop foo'.format(supervisor.workdir))
+    root.component.deploy()
+    assert 'RUNNING' in supervisor.cmd(
+        '{}/bin/supervisorctl status foo'.format(supervisor.workdir))[0]
+
+
+@pytest.mark.slow
 def test_enable_false_reports_not_running_when_daemon_stopped(root):
     supervisor = batou.lib.supervisor.Supervisor(
         enable=False,


### PR DESCRIPTION
This is a simliar issue as 1409cdc, supervisor-4 uses way more nonzero return codes