### PR TITLE
Fix a warning while building documentation

### DIFF
--- a/src/batou/component.py
+++ b/src/batou/component.py
@@ -412,8 +412,8 @@ class Component(object):
     def log(self, message, *args):
         """Log a message to console during deployment.
 
-        The message is %-substituted with *args, if it is put out. and prefixed
-        with the hostname automatically.
+        The message is %-substituted with :py:attr:`\*args`, if it is put out. and
+        prefixed with the hostname automatically.
 
         Use this message to add additional status to the deployment output,
         i.e. "Deploying Version X".


### PR DESCRIPTION
This solves: src/batou/component.py:docstring of batou.component.Component.log:3: WARNING: Inline emphasis start-string without end-string.