### PR TITLE
Configure usage of `tox`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,11 @@ setup(
     ],
     extras_require={
         'test': [
+            'pytest',
+            'pytest-black',
+            'pytest-timeout',
+            'pytest-coverage',
+            'mock',
         ],
     },
     entry_points="""

--- a/src/batou/tests/test_remote_core.py
+++ b/src/batou/tests/test_remote_core.py
@@ -267,6 +267,13 @@ def test_channelexec_handle_exception(remote_core_mod):
         next(response)
 
 
+@mock.patch.dict(
+    os.environ,
+    {
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    },
+)
 def test_git_remote_init_bundle(tmpdir):
     source = tmpdir.mkdir("source")
     dest = tmpdir.mkdir("dest")
@@ -286,6 +293,13 @@ def test_git_remote_init_bundle(tmpdir):
     assert "bar" == dest.join("foo.txt").read()
 
 
+@mock.patch.dict(
+    os.environ,
+    {
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    },
+)
 def test_git_remote_init_pull(tmpdir):
     source = tmpdir.mkdir("source")
     dest = tmpdir.mkdir("dest")

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist =
+    py35, py36, py37, py38, py39
+skip_missing_interpreters = true
+
+[testenv]
+usedevelop = true
+extras = test
+commands = pytest src/batou/tests {posargs}


### PR DESCRIPTION
Examples:

- run tests for Python 3.6
`tox -e py36`

- run tests for Python 3.7 and Python 3.9
`tox -e py37 -e py39`

- run only the git tests on Python 3.8
`tox -e py38 -- -k test_git`

modified:   setup.py
modified:   src/batou/tests/test_remote_core.py
new file:   tox.ini