### PR TITLE
Fix compability issue with Python 3.9

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,9 @@
   introduced in batou 2.1.
   ([#98](https://github.com/flyingcircusio/batou/issues/98))
 
-- Instruction how to create new project
+- Make batou compatible with Python 3.9, ie asyncio's `all_tasks`
+  has been moved to a new location.
+  ([#93](https://github.com/flyingcircusio/batou/issues/93))
 
 
 2.1 (2020-09-09)

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ The project is licensed under the 2-clause BSD license.
   introduced in batou 2.1.
   ([#98](https://github.com/flyingcircusio/batou/issues/98))
 
+- Make batou compatible with Python 3.9, ie asyncio's `all_tasks`
+  has been moved to a new location.
+  ([#93](https://github.com/flyingcircusio/batou/issues/93))
+
 
 2.1 (2020-09-09)
 ----------------

--- a/src/batou/deploy.py
+++ b/src/batou/deploy.py
@@ -193,16 +193,15 @@ class Deployment(object):
         # for Python 3.7 and upwards
         # confer https://docs.python.org/3/whatsnew/3.7.html
         # and https://docs.python.org/3.9/whatsnew/3.9.html
-        if sys.version_info < (3, 7):
-            pending = asyncio.Task.all_tasks()
-            while pending:
-                self.loop.run_until_complete(asyncio.gather(*pending))
-                pending = {t for t in asyncio.Task.all_tasks() if not t.done()}
+        if sys.version_info < 3.7:
+            all_tasks = asyncio.Task.all_tasks
         else:
-            pending = asyncio.all_tasks()
-            while pending:
-                self.loop.run_until_complete(asyncio.gather(*pending))
-                pending = {t for t in asyncio.all_tasks() if not t.done()}
+            all_tasks = asyncio.all_tasks
+        get_pending = lambda: { t for t in  all_tasks() if not t.done() }
+        pending = get_pending()
+        while pending:
+            self.loop.run_until_complete(asyncio.gather(*pending))
+            pending = get_pending()
 
     def disconnect(self):
         output.step("main", "Disconnecting from nodes ...", debug=True)


### PR DESCRIPTION
`asyncio.Task.all_tasks` has been deprecated with Python 3.7 and removed
in Python 3.9. Now, you have to use `asyncio.all_tasks`.

modified:   CHANGES.md
modified:   README.md
modified:   src/batou/deploy.py