### PR TITLE
Fix bug preventing to use `nagios=True` in for Supervisor components.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,9 @@
 2.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix bug preventing to use `nagios=True` in for Supervisor components,
+  introduced in batou 2.1.
+  ([#98](https://github.com/flyingcircusio/batou/issues/98))
 
 
 2.1 (2020-09-09)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ The project is licensed under the 2-clause BSD license.
 ## Changelog
 
 
+2.2 (unreleased)
+----------------
+
+- Fix bug preventing to use `nagios=True` in for Supervisor components,
+  introduced in batou 2.1.
+  ([#98](https://github.com/flyingcircusio/batou/issues/98))
+
+
 2.1 (2020-09-09)
 ----------------
 

--- a/src/batou/lib/nagios.py
+++ b/src/batou/lib/nagios.py
@@ -4,7 +4,7 @@ import os.path
 
 
 def ServiceCheck(description, **kw):
-    if kw.get("nrpe", False):
+    if kw.pop("nrpe", False):
         return NRPEService(description, **kw)
     return Service(description, **kw)
 

--- a/src/batou/lib/tests/test_supervisor.py
+++ b/src/batou/lib/tests/test_supervisor.py
@@ -88,3 +88,13 @@ def test_enable_true_reports_not_running_when_daemon_stopped(root, supervisor):
     supervisor.cmd("{}/bin/supervisorctl shutdown".format(supervisor.workdir))
     # assert nothing raised
     root.component.deploy()
+
+
+def test_setting_nagios_to_True_creates_a_nagios_nrpe_service(root):
+    supervisor = batou.lib.supervisor.Supervisor(nagios=True)
+    root.component += supervisor
+    # assert nothing raised
+    root.component.configure()
+    assert "NRPEService" in [
+        x.__class__.__name__ for x in supervisor.sub_components
+    ]


### PR DESCRIPTION
This bug was intruduced by #65 in batou 2.1.

Fixes #98.