### PR TITLE
Blacken `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,31 +13,30 @@ def project_path(*names):
     return os.path.join(*names)
 
 
-version = open(project_path('src/batou/version.txt')).read().strip()
+version = open(project_path("src/batou/version.txt")).read().strip()
 
 
-with open(project_path('README.md'), 'w') as out:
-    for f in ['README.md.in', 'CHANGES.md']:
-        with open(project_path(f), 'r') as f:
+with open(project_path("README.md"), "w") as out:
+    for f in ["README.md.in", "CHANGES.md"]:
+        with open(project_path(f), "r") as f:
             out.write(f.read())
 
 
 setup(
-    name='batou',
+    name="batou",
     version=version,
     install_requires=[
-        'ConfigUpdater',
-        'Jinja2',
-        'requests',
+        "ConfigUpdater",
+        "Jinja2",
+        "requests",
         # ConfigUpdater does not manage its minimum requirements correctly.
-        'setuptools>=38.3',
-        'execnet',
-        'pyyaml',
-        'py',
+        "setuptools>=38.3",
+        "execnet",
+        "pyyaml",
+        "py",
     ],
     extras_require={
-        'test': [
-        ],
+        "test": [],
     },
     entry_points="""
         [console_scripts]
@@ -49,11 +48,11 @@ setup(
         [zest.releaser.postreleaser.after]
             update_requirements = batou.release:update_requirements
     """,
-    author='Christian Theune',
-    author_email='ct@flyingcircus.io',
-    license='BSD (2-clause)',
-    url='https://batou.readthedocs.io/en/latest/',
-    keywords='deployment',
+    author="Christian Theune",
+    author_email="ct@flyingcircus.io",
+    license="BSD (2-clause)",
+    url="https://batou.readthedocs.io/en/latest/",
+    keywords="deployment",
     classifiers="""\
 License :: OSI Approved :: BSD License
 Programming Language :: Python
@@ -63,17 +62,26 @@ Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3 :: Only
-"""[:-1].split('\n'),
+"""[
+        :-1
+    ].split(
+        "\n"
+    ),
     description=__doc__.strip(),
-    long_description=open(project_path('README.md')).read(),
-    long_description_content_type='text/markdown',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
+    long_description=open(project_path("README.md")).read(),
+    long_description_content_type="text/markdown",
+    packages=find_packages("src"),
+    package_dir={"": "src"},
     include_package_data=True,
-    data_files=[('', glob.glob(project_path('*.txt')) +
-                     glob.glob(project_path('*.in')) +
-                     glob.glob(project_path('*.md')))],
+    data_files=[
+        (
+            "",
+            glob.glob(project_path("*.txt"))
+            + glob.glob(project_path("*.in"))
+            + glob.glob(project_path("*.md")),
+        )
+    ],
     zip_safe=False,
-    test_suite='batou.tests',
-    python_requires='>=3.5',
+    test_suite="batou.tests",
+    python_requires=">=3.5",
 )


### PR DESCRIPTION
This was done manually, which means "regressions" can happen.

Usually, `black` is run either via `tox` or `pre-commit`, but here
`pytest-black` is used, which I am not familiar with.

closes #96 

modified:   setup.py