### PR TITLE
Backport zsh to 2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,13 +4,14 @@
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Backport compatibility for Python 3.9.
 
 
 2.0.1 (2020-11-13)
 ------------------
 
-- Backport compatibility for Python 3.9.
+- Bug: zsh compatibility on the remote host was broken with more
+  complex sudo mechanism. Added a ZSH workaround.
 
 
 2.0 (2020-07-15)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,14 +4,14 @@
 2.0.2 (unreleased)
 ------------------
 
-- Backport compatibility for Python 3.9.
+- Bug: zsh compatibility on the remote host was broken with more
+  complex sudo mechanism. Added a ZSH workaround.
 
 
 2.0.1 (2020-11-13)
 ------------------
 
-- Bug: zsh compatibility on the remote host was broken with more
-  complex sudo mechanism. Added a ZSH workaround.
+- Backport compatibility for Python 3.9.
 
 
 2.0 (2020-07-15)

--- a/README.md
+++ b/README.md
@@ -87,10 +87,17 @@ The project is licensed under the 2-clause BSD license.
 ## Changelog
 
 
-2.0.1 (2020-11-13)
+2.0.2 (unreleased)
 ------------------
 
 - Backport compatibility for Python 3.9.
+
+
+2.0.1 (2020-11-13)
+------------------
+
+- Bug: zsh compatibility on the remote host was broken with more
+  complex sudo mechanism. Added a ZSH workaround.
 
 
 2.0 (2020-07-15)

--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ The project is licensed under the 2-clause BSD license.
 2.0.2 (unreleased)
 ------------------
 
-- Backport compatibility for Python 3.9.
+- Bug: zsh compatibility on the remote host was broken with more
+  complex sudo mechanism. Added a ZSH workaround.
 
 
 2.0.1 (2020-11-13)
 ------------------
 
-- Bug: zsh compatibility on the remote host was broken with more
-  complex sudo mechanism. Added a ZSH workaround.
+- Backport compatibility for Python 3.9.
 
 
 2.0 (2020-07-15)

--- a/src/batou/host.py
+++ b/src/batou/host.py
@@ -169,6 +169,7 @@ class RemoteHost(Host):
         #   irregardless of the local configuration of env_reset, etc.
 
         CONDITIONAL_SUDO = """\
+if [ -n "$ZSH_VERSION" ]; then setopt SH_WORD_SPLIT; fi;
 if [ \"$USER\" = \"{user}\" ]; then \
 pre=\"\"; else pre=\"sudo -ni -u {user}\"; fi; $pre\
 """.format(user=self.service_user)

--- a/src/batou/requirements.txt
+++ b/src/batou/requirements.txt
@@ -5,10 +5,10 @@ chardet==3.0.4
 idna==2.8
 urllib3==1.25.3
 apipkg==1.5
-Jinja2==2.10.1
+Jinja2==2.11.2
 requests==2.22.0
 setuptools==50.3.2
 execnet==1.7.1
 PyYAML==5.1.2
-py==1.8.0
+py==1.8.2
 six==1.12.0


### PR DESCRIPTION
Make ZSH on the remote side work in batou 2.0, too.