### PR TITLE
Fix shipping of deployment code with git-bundle when using a branch.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 2.2.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix shipping of deployment code with git-bundle when using a branch. Before the entire branch history was uploaded with each deployment to each host (#131)
 
 
 2.2.3 (2021-01-20)

--- a/src/batou/remote_core.py
+++ b/src/batou/remote_core.py
@@ -274,13 +274,10 @@ def hg_update_working_copy(branch):
 git_origin = "batou-bundle"
 
 
-def git_current_head(branch):
+def git_current_head():
     target = target_directory
     os.chdir(target)
-    id, err = cmd(
-        "git rev-parse {branch}".format(branch=branch),
-        acceptable_returncodes=[0, 128],
-    )
+    id, err = cmd('git rev-parse HEAD', acceptable_returncodes=[0, 128])
     id = id.strip()
     return id if b"unknown revision" not in err else None
 

--- a/src/batou/repository.py
+++ b/src/batou/repository.py
@@ -281,7 +281,7 @@ class GitPullRepository(GitRepository):
 class GitBundleRepository(GitRepository):
 
     def _ship(self, host):
-        head = host.rpc.git_current_head(self.branch)
+        head = host.rpc.git_current_head()
         if head is None:
             bundle_range = self.branch
         else:


### PR DESCRIPTION
Before the entire branch history was uploaded with each deployment to each host (#131)