### PR TITLE
workaround rocket.chat integration issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,7 @@ jobs:
         run: bin/tox
 
       - name: Rocket.Chat Notification
+        continue-on-error: true
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         if: always()
         with:


### PR DESCRIPTION
Currently, the build breaks for all external pull requests, ie when someone makes a PR from a fork, as the fork has no access to `secrets.ROCKETCHAT_WEBHOOK`.

Afaik there is currently no safe way to share a secret with a fork.

In order to "make builds green again" for external contributors, let's `continue-on-error` when the rocket chat notification job fails.