### PR TITLE
Fix bootstrap

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -7,7 +7,7 @@ oops() {
     exit 1
 }
 
-curl -sL https://github.com/flyingcircusio/appenv/raw/master/src/appenv.py -o batou || oops "failed to download appenv"
+curl -sL https://raw.githubusercontent.com/flyingcircusio/batou/master/appenv.py -o batou || oops "failed to download appenv"
 chmod +x batou
 echo "batou>=2.0b12" >> requirements.txt
 sed -e 's!.*batou_ext.*!batou_ext @  https://github.com/flyingcircusio/batou_ext/archive/f2d1ce75a15eeaf4701686bb64e6616c5c35e31c.zip#sha256=4242d65a4cb0721812a308d2cfa87d647ba78f3e03ae4d189f9d2ac78157df93!' requirements.txt > requirements.txt.new

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py35, py36, py37, py38, py39, pre-commit
+    py36, py37, py38, py39, pre-commit
 skip_missing_interpreters = true
 allowlist_externals=git
 


### PR DESCRIPTION
This upstream commit https://github.com/flyingcircusio/appenv/commit/ab919b1f6e5be6a7ed3d47a1fe2daeb133dc3c87 broke the current way of bootstrapping a batou project. This is a workaround causing the following error when attempting to update the `requirements.lock` file. 

```
./batou appenv-update-lockfile
Running unclean installation from requirements.txt
Ensuring unclean install ...
usage: batou [-h] [-d] {deploy,secrets} ...
batou: error: invalid choice: 'appenv-update-lockfile' (choose from 'deploy', 'secrets')
```