### PR TITLE
document how to run test suite without mercurial

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,28 @@ Check the [detailed documentation](http://batou.readthedocs.org) to get going wi
 * self-bootstrapping and self-updating - no additional
   scripting needed
 
+## Run tests
+
+We use [tox](https://tox.readthedocs.io/en/latest/) to run the test suite.
+
+You can run the complete test suite for all supported Python interpreters by just entering `tox`.
+
+You can also run a specific `testenv`, e.g. `tox -e py39`.
+
+If you have not installed `mercurial`,
+which is a hard dependency of this project,
+you can run `tox -e skip-mercurial`.
+
 ## License
 
 The project is licensed under the 2-clause BSD license.
 ## Changelog
+
+
+2.3b2 (unreleased)
+------------------
+
+- Nothing changed yet.
 
 
 2.3b1 (2021-05-21)

--- a/README.md.in
+++ b/README.md.in
@@ -77,6 +77,18 @@ Check the [detailed documentation](http://batou.readthedocs.org) to get going wi
 * self-bootstrapping and self-updating - no additional
   scripting needed
 
+## Run tests
+
+We use [tox](https://tox.readthedocs.io/en/latest/) to run the test suite.
+
+You can run the complete test suite for all supported Python interpreters by just entering `tox`.
+
+You can also run a specific `testenv`, e.g. `tox -e py39`.
+
+If you have not installed `mercurial`,
+which is a hard dependency of this project,
+you can run `tox -e skip-mercurial`.
+
 ## License
 
 The project is licensed under the 2-clause BSD license.

--- a/tox.ini
+++ b/tox.ini
@@ -5,16 +5,21 @@ skip_missing_interpreters = true
 allowlist_externals=git
 
 [testenv]
+description = run the test suite with pytest
 usedevelop = true
 extras = test
 commands = pytest src/batou {posargs}
 
-
 [testenv:pre-commit]
-basepython = python3.9
 description = This env runs all linters configured in .pre-commit-config.yaml
+basepython = python3.9
 skip_install = true
 deps =
     pre-commit
 commands =
     pre-commit run --all-files --show-diff-on-failure
+
+[testenv:skip-mercurial]
+description = run test suite with the exception of tests for mercurial
+baseython = python3.9
+commands = pytest --ignore=src/batou/lib/tests/test_mercurial.py src/batou {posargs}


### PR DESCRIPTION
As not everybody has mercurial installed, now you can run the test suite
with `tox - e skip-mercurial`.