### PR TITLE
Run only the desired Python version in GHA.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,4 +37,4 @@ jobs:
         run: set
 
       - name: Test
-        run: bin/tox
+        run: bin/tox -e py


### PR DESCRIPTION
Previously the other Python versions were only skipped because of missing interpreters.