### PR TITLE
Ensure endtoend tests use correct Python version.

### DIFF
--- a/develop.sh
+++ b/develop.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-rm -rf .Python bin lib include .tox examples/*/.batou
+rm -rf .Python bin lib include .tox examples/*/.appenv
 
 python3 -m venv .
 bin/pip install --upgrade -r requirements-dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ allowlist_externals=git
 
 [testenv]
 usedevelop = true
+setenv =
+    APPENV_BEST_PYTHON = {envpython}
 extras = test
 commands = pytest src/batou {posargs}
 


### PR DESCRIPTION
Before this commit the newest usable Python version was used.
This locally leads to test failures in examples/error* when Python 3.10 is installed as this version has different error messages.

Additionally fix the name of the created environment in examples which is now named `.appenv`.