### PR TITLE
Allow to run tests of parts of the project.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ usedevelop = true
 setenv =
     APPENV_BEST_PYTHON = {envpython}
 extras = test
-commands = pytest src/batou {posargs}
+commands = pytest {posargs}
 
 
 [testenv:pre-commit]


### PR DESCRIPTION
The path to the tests is already configured in `pytest.ini`.
Setting it here again prevents developers from calling tox with a path like: `tox -epy39 -- src/batou/secrets`.