### PR TITLE
Render a better error message if gpg failed to decrypt a secrets file.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,4 +37,4 @@ jobs:
         run: set
 
       - name: Test
-        run: bin/tox -e py
+        run: bin/tox -e py -- -vv

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
 
 - NetLoc objects are now comparable. (#88)
 
+- Render a better error message if gpg failed to decrypt a secrets file.
+  ([#123](https://github.com/flyingcircusio/batou/issues/123))
+
 - Support `ls` syntax in mode attributes. (#61)
 
 

--- a/src/batou/__init__.py
+++ b/src/batou/__init__.py
@@ -30,6 +30,24 @@ class FileLockedError(ReportingException):
         output.error(str(self))
 
 
+class GPGCallError(ReportingException):
+    """There was an error calling GPG on encrypted file."""
+
+    def __init__(self, command, exitcode, output):
+        self.command = ' '.join(command)
+        self.exitcode = str(exitcode)
+        self.output = output.decode('ascii', errors='replace')
+
+    def __str__(self):
+        return f"Error while calling {self.command}: {self.exitcode}"
+
+    def report(self):
+        output.error('Error while calling GPG')
+        output.tabular('command', self.command, red=True)
+        output.tabular('exit code', self.exitcode)
+        output.tabular('message', self.output, separator=":\n")
+
+
 class UpdateNeeded(AssertionError):
     """A component requires an update."""
 

--- a/src/batou/secrets/tests/test_secrets.py
+++ b/src/batou/secrets/tests/test_secrets.py
@@ -1,13 +1,13 @@
 from batou.secrets.encryption import EncryptedConfigFile, EncryptedFile
 from batou.secrets.encryption import NEW_FILE_TEMPLATE
 from batou.secrets import add_secrets_to_environment
+import batou
 import configparser
 import mock
 import os
 import os.path
 import pytest
 import shutil
-import subprocess
 import tempfile
 
 FIXTURE = os.path.join(os.path.dirname(__file__), "fixture")
@@ -59,7 +59,7 @@ def test_caches_cleartext():
 def test_decrypt_missing_key(monkeypatch):
     monkeypatch.setitem(os.environ, "GNUPGHOME", '/tmp')
 
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(batou.GPGCallError):
         EncryptedConfigFile(encrypted_file)
         f = secrets.__enter__()
         f.read()

--- a/src/batou/tests/test_endtoend.py
+++ b/src/batou/tests/test_endtoend.py
@@ -64,8 +64,7 @@ ERROR: Error while calling GPG
    command: gpg --decrypt secrets/errors.cfg
  exit code: 2
    message:
-gpg: ... 2013-07-10
-      "Christian Zagrodnick (replaces C17A4728) <christian@zagrodnick.de>"
+gpg: ...
 ...
 ERROR: Failed loading component file
       File: .../examples/errors/components/component5/component.py

--- a/src/batou/tests/test_endtoend.py
+++ b/src/batou/tests/test_endtoend.py
@@ -49,6 +49,45 @@ ERROR: Secrets section for unknown component found
 """)
 
 
+def test_example_errors_gpg_cannot_decrypt(monkeypatch):
+    monkeypatch.setitem(os.environ, "GNUPGHOME", '')
+    os.chdir("examples/errors")
+    out, _ = cmd("./batou deploy errors", acceptable_returncodes=[1])
+    assert out == Ellipsis("""\
+batou/2... (cpython 3...)
+================================== Preparing ===================================
+main: Loading environment `errors`...
+main: Verifying repository ...
+main: Loading secrets ...
+
+ERROR: Error while calling GPG
+   command: gpg --decrypt secrets/errors.cfg
+ exit code: 2
+   message:
+gpg: ... 2013-07-10
+      "Christian Zagrodnick (replaces C17A4728) <christian@zagrodnick.de>"
+...
+ERROR: Failed loading component file
+      File: .../examples/errors/components/component5/component.py
+ Exception: invalid syntax (component.py, line 1)
+
+ERROR: Failed loading component file
+      File: .../examples/errors/components/component6/component.py
+ Exception: No module named 'asdf'
+
+ERROR: Missing component
+ Component: missingcomponent
+      Host: localhost
+
+ERROR: Superfluous section in environment configuration
+   Section: superfluoussection
+
+ERROR: Override section for unknown component found
+ Component: nonexisting-component-section
+======================= DEPLOYMENT FAILED (during load) ========================
+""")
+
+
 def test_example_errors_late():
     os.chdir("examples/errors2")
     out, _ = cmd("./batou deploy errors", acceptable_returncodes=[1])


### PR DESCRIPTION
fixes #123

The rendered error message for running `./batou deploy errors` in `examples/errors` no looks like this on my machine:

```console
ERROR: Error while calling GPG
   command: gpg --decrypt secrets/errors.cfg
 exit code: 2
   message:
gpg: encrypted with 2048-bit RSA key, ID 6226C1278124EF96, created 2013-07-10
      "Christian Zagrodnick (replaces C17A4728) <christian@zagrodnick.de>"
gpg: encrypted with RSA key, ID 2ECB66D745EA9BCE
gpg: decryption failed: No secret key
```
