### PR TITLE
Render an error message if `batou secrets summary` fails during decryption.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,9 +15,13 @@
 
 - Fail if an attribute is set both in environment and via secrets.
   ([#28](https://github.com/flyingcircusio/batou/issues/28))
+
 - Raise exception when calling `batou secrets add` or `batou secrets remove`
   with an unknown environment name.
   ([#143](https://github.com/flyingcircusio/batou/issues/143))
+
+- Render an error message if `batou secrets summary` fails during decryption.
+  ([#165](https://github.com/flyingcircusio/batou/issues/165))
 
 
 2.3b1 (2021-05-21)

--- a/src/batou/__init__.py
+++ b/src/batou/__init__.py
@@ -39,7 +39,7 @@ class GPGCallError(ReportingException):
         self.output = output.decode('ascii', errors='replace')
 
     def __str__(self):
-        return f"Error while calling {self.command}: {self.exitcode}"
+        return f"Exitcode {self.exitcode} while calling: {self.command}"
 
     def report(self):
         output.error('Error while calling GPG')

--- a/src/batou/main.py
+++ b/src/batou/main.py
@@ -146,7 +146,7 @@ Remove a user's key from one or more secret files.
     del func_args["func"]
     del func_args["debug"]
     try:
-        args.func(**func_args)
+        return args.func(**func_args)
     except batou.FileLockedError as e:
         # Nicer error reporting for non-deployment commands.
         print("File already locked: {}".format(e.filename))

--- a/src/batou/secrets/manage.py
+++ b/src/batou/secrets/manage.py
@@ -2,8 +2,10 @@
 
 from .encryption import EncryptedConfigFile
 from batou import ConfigurationError
+from batou import GPGCallError
 import glob
 import os.path
+import sys
 
 
 class UnknownEnvironmentError(ValueError):
@@ -130,9 +132,14 @@ def summary(**kw):
     if not os.path.exists("secrets"):
         print("No secrets.")
 
-    for e in Environment.all():
-        print(e.name)
-        e.summary()
+    try:
+        for e in Environment.all():
+            print(e.name)
+            e.summary()
+    except GPGCallError as e:
+        print(e, file=sys.stderr)
+        print(e.output, file=sys.stderr)
+        return 1  # exit code
 
 
 def add_user(keyid, environments, **kw):

--- a/src/batou/secrets/tests/test_manage.py
+++ b/src/batou/secrets/tests/test_manage.py
@@ -2,8 +2,10 @@ from ..manage import UnknownEnvironmentError
 from ..manage import add_user
 from ..manage import remove_user
 from ..manage import summary
+import os
 import pytest
 import shutil
+import textwrap
 
 
 @pytest.mark.parametrize('func', (add_user, remove_user))
@@ -33,3 +35,33 @@ def test_manage__2(tmp_path, monkeypatch, capsys):
     summary()
     out, err = capsys.readouterr()
     assert 'cz@flyingcircus.io' in out
+
+
+def test_manage__summary__1(capsys, monkeypatch):
+    """It prints a summary of the environments, members and secret files."""
+    monkeypatch.chdir('examples/errors')
+    assert summary() is None
+    out, err = capsys.readouterr()
+    expected = textwrap.dedent("""\
+        errors
+        \t members
+        \t\t- ct@gocept.com
+        \t\t- cz@flyingcircus.io
+        \t secret files
+        \t\t(none)
+
+    """)
+    assert out == expected
+    assert err == ''
+
+
+def test_manage__summary__2(capsys, monkeypatch):
+    """It prints an error message on decoding problems."""
+    monkeypatch.chdir('examples/errors')
+    monkeypatch.setitem(os.environ, "GNUPGHOME", '')
+    assert summary() == 1  # exit code
+    out, err = capsys.readouterr()
+    expected = ('Exitcode 2 while calling:'
+                ' gpg -q --no-tty --batch --decrypt secrets/errors.cfg')
+    assert out == ''
+    assert err.startswith(expected)


### PR DESCRIPTION
Example output for `examples/errors` now looks like this:

```console
$ ./batou secrets summary
Running unclean installation from requirements.txt
Ensuring unclean install ...
Exitcode 2 while calling: gpg -q --no-tty --batch --decrypt secrets/errors.cfg
gpg: decryption failed: No secret key

```

An exit code of `1` is set to signal the problem.

Fixes #165