### PR TITLE
 re #89: Avoid implicit conversion of Attribute defaults.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,9 @@
 
 - Do not render diffs for files which contain contents of `secrets/*`.
   ([#91](https://github.com/flyingcircusio/batou/issues/91))
+- Avoid implicit conversion of Attribute defaults. In cases where the default
+  value should be converted, use `default_conf_string`.
+  ([#89](https://github.com/flyingcircusio/batou/issues/89))
 
 - Assure that `requirements.lock` is build with the oldest supported Python
   version to keep it consistent – newer Python versions have included some
@@ -50,6 +53,7 @@
 - Improve error message for DNS lookup semantics.
 
 - Adapt `bootstrap.sh` to the use of appenv.
+
 
 2.3b1 (2021-05-21)
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,40 +4,38 @@
 2.3b2 (unreleased)
 ------------------
 
-- Raise an error if an internet protocol family is used but not configured.
-  ([#189](https://github.com/flyingcircusio/batou/issues/189))
-
-- Fix Python 3 compatibility with some Mercurial-based batou repositories.
-
-- NetLoc objects are now comparable.
-  ([#88](https://github.com/flyingcircusio/batou/issues/88))
-
-- Render a better error message if gpg failed to decrypt a secrets file.
-  ([#123](https://github.com/flyingcircusio/batou/issues/123))
-
-- Support `ls` syntax in mode attributes.
-  ([#61](https://github.com/flyingcircusio/batou/issues/61))
-
-- Integrate `remote-pdb` to debug batou runs.
-  ([#199](https://github.com/flyingcircusio/batou/issues/199))
+### Action needed
 
 - Fail if an attribute is set both in environment and via secrets.
   ([#28](https://github.com/flyingcircusio/batou/issues/28))
 
-- Raise exception when calling `batou secrets add` or `batou secrets remove`
-  with an unknown environment name.
-  ([#143](https://github.com/flyingcircusio/batou/issues/143))
-
-- Render an error message if `batou secrets summary` fails during decryption.
-  ([#165](https://github.com/flyingcircusio/batou/issues/165))
-
 - Avoid implicit conversion of Attribute defaults. In cases where the default
-  value should be converted, use `default_conf_string`.
+  value should be converted, use `default_conf_string`. This may result in
+  some changes if your code relied on this implicit conversion. If you use
+  `batou_ext`, update to a current commit..
   ([#89](https://github.com/flyingcircusio/batou/issues/89))
+
+- Raise an error if an internet protocol family is used but not configured.
+  ([#189](https://github.com/flyingcircusio/batou/issues/189))
+
+### Bug fixes
+
+- Fix Python 3 compatibility with some Mercurial-based batou repositories.
+
+- Adapt `bootstrap.sh` to the use of appenv.
+
+### Features
+
+- Integrate `remote-pdb` to debug batou runs.
+  ([#199](https://github.com/flyingcircusio/batou/issues/199))
+
+- NetLoc objects are now comparable.
+  ([#88](https://github.com/flyingcircusio/batou/issues/88))
 
 - Enhance file `Mode` objects to accept integers, octal mode strings
   and 'rwx' strings as the `mode` argument. This allows homogenous use
   in Python code and overrides through config files.
+  ([#61](https://github.com/flyingcircusio/batou/issues/61))
 
 - Do not render diffs for files which contain contents of `secrets/*`.
   ([#91](https://github.com/flyingcircusio/batou/issues/91))
@@ -55,9 +53,19 @@
   We provide a built-in plugin to support NixOS development containers
   that feel similar to the Flying Circus VM platform.
 
+### Other changes
+
 - Improve error message for DNS lookup semantics.
 
-- Adapt `bootstrap.sh` to the use of appenv.
+- Render a better error message if gpg failed to decrypt a secrets file.
+  ([#123](https://github.com/flyingcircusio/batou/issues/123))
+
+- Raise exception when calling `batou secrets add` or `batou secrets remove`
+  with an unknown environment name.
+  ([#143](https://github.com/flyingcircusio/batou/issues/143))
+
+- Render an error message if `batou secrets summary` fails during decryption.
+  ([#165](https://github.com/flyingcircusio/batou/issues/165))
 
 
 2.3b1 (2021-05-21)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,11 +31,16 @@
 - Render an error message if `batou secrets summary` fails during decryption.
   ([#165](https://github.com/flyingcircusio/batou/issues/165))
 
-- Do not render diffs for files which contain contents of `secrets/*`.
-  ([#91](https://github.com/flyingcircusio/batou/issues/91))
 - Avoid implicit conversion of Attribute defaults. In cases where the default
   value should be converted, use `default_conf_string`.
   ([#89](https://github.com/flyingcircusio/batou/issues/89))
+
+- Enhance file `Mode` objects to accept integers, octal mode strings
+  and 'rwx' strings as the `mode` argument. This allows homogenous use
+  in Python code and overrides through config files.
+
+- Do not render diffs for files which contain contents of `secrets/*`.
+  ([#91](https://github.com/flyingcircusio/batou/issues/91))
 
 - Assure that `requirements.lock` is build with the oldest supported Python
   version to keep it consistent – newer Python versions have included some

--- a/doc/source/components/files.txt
+++ b/doc/source/components/files.txt
@@ -68,7 +68,7 @@ Creates a file. The main parameter for File is the target path. A ``File`` insta
 
 .. py:attribute:: mode
 
-    Unix permission mode (octal number, e.g. 0o755)
+    Unix permission mode. Can be given as an integer value (`0o755`) or as an octal integer string (`'755'`) or as a unix mode string similar to the output of `ls -l` (`'rwx--x--x'`).
 
 .. py:attribute:: leading
 

--- a/examples/errors/components/component7/component.py
+++ b/examples/errors/components/component7/component.py
@@ -1,0 +1,8 @@
+from batou.component import Component, Attribute
+
+
+class Component7(Component):
+    # Separate components.py as error would render components from
+    # component1/component.py as missing
+
+    only_one_default = Attribute("literal", False, "False")

--- a/examples/errors/environments/errors.cfg
+++ b/examples/errors/environments/errors.cfg
@@ -2,7 +2,7 @@
 connect_method = local
 
 [hosts]
-localhost = component1, component2, component3, component4, missingcomponent, cycle1, cycle2, dnsproblem, crontab
+localhost = component1, component2, component3, component4, component7, missingcomponent, cycle1, cycle2, dnsproblem, crontab
 
 [component:component1]
 do_what_is_needed = false

--- a/src/batou/component.py
+++ b/src/batou/component.py
@@ -1071,9 +1071,7 @@ class Attribute(object):
                 and default_conf_string is not ATTRIBUTE_NODEFAULT):
             raise batou.ConfigurationError(
                 'Attributes only support one of those parameters:'
-                ' `default` or `default_conf_string`.',
-                self,
-            )
+                ' either `default` or `default_conf_string`.', self)
         self.default = default
         self.default_conf_string = default_conf_string
         self.expand = expand

--- a/src/batou/lib/cron.py
+++ b/src/batou/lib/cron.py
@@ -39,7 +39,7 @@ class CronTab(Component):
     purge = False
 
     # Dict of additional environment variables
-    env = Attribute("literal", "{}")
+    env = Attribute("literal", default_conf_string="{}")
 
     def configure(self):
         self.jobs = self.require(CronJob.key, host=self.host, strict=False)

--- a/src/batou/lib/file.py
+++ b/src/batou/lib/file.py
@@ -81,7 +81,7 @@ class File(Component):
             if isinstance(self.mode, int):
                 mode_ = self.mode
             else:
-                mode_ = Mode.from_config_string(Mode_, self.mode)
+                mode_ = Mode.mode.from_config_string(Mode_, self.mode)
             Mode_.mode = mode_
 
         # no content or source given but file with same name

--- a/src/batou/lib/file.py
+++ b/src/batou/lib/file.py
@@ -74,7 +74,15 @@ class File(Component):
         # The mode needs to be set early to allow batou to get out of
         # accidental "permission denied" situations.
         if self.mode:
-            self += Mode(self.path, mode=self.mode)
+            Mode_ = Mode(self.path)
+            self += Mode_
+            # We need to explicitly trigger the conversion at this point, as
+            # passed parameters are not converted implicitly.
+            if isinstance(self.mode, int):
+                mode_ = self.mode
+            else:
+                mode_ = Mode.from_config_string(Mode_, self.mode)
+            Mode_.mode = mode_
 
         # no content or source given but file with same name
         # exists

--- a/src/batou/lib/supervisor.py
+++ b/src/batou/lib/supervisor.py
@@ -159,7 +159,7 @@ process_name={{component.name}}
 
 class Supervisor(Component):
 
-    address = Attribute(Address, "localhost:9001")
+    address = Attribute(Address, default_conf_string="localhost:9001")
     buildout_cfg = os.path.join(
         os.path.dirname(__file__), "resources", "supervisor.buildout.cfg")
     supervisor_conf = os.path.join(
@@ -169,18 +169,18 @@ class Supervisor(Component):
     logdir = None
     loglevel = "info"
 
-    logrotate = Attribute("literal", "False")
-    nagios = Attribute("literal", "False")
+    logrotate = Attribute("literal", False)
+    nagios = Attribute("literal", False)
 
     # Allows turning "everything off" via environment configuration
-    enable = Attribute("literal", "True")
+    enable = Attribute("literal", True)
     # Hot deployments: if supervisor is already running stuff - keep them
     # running
     # Cold deployments: if supervisor is already running: let it run
     # but shutdown all processes before continuing
     deployment_mode = Attribute(str, "hot")
     max_startup_delay = Attribute(int, 0)
-    wait_for_running = Attribute("literal", "True")
+    wait_for_running = Attribute("literal", True)
     pidfile = Attribute(str, "supervisord.pid", map=True)
     socketpath = Attribute(
         str, "{{component.workdir}}/supervisor.sock", map=True)

--- a/src/batou/lib/tests/test_file.py
+++ b/src/batou/lib/tests/test_file.py
@@ -7,6 +7,7 @@ import os
 import pwd
 from stat import S_IMODE
 
+import batou
 import pytest
 import yaml
 from batou.lib.file import (BinaryFile, Content, Directory, File,
@@ -856,6 +857,25 @@ def test_mode_ensures_mode_for_files(root, input, expected):
 
     root.component.deploy()
     assert not mode.changed
+
+
+def test_mode_converts_to_numeric(root):
+    path = "path"
+    open("work/mycomponent/" + path, "w").close()
+
+    with pytest.raises(batou.ConfigurationError) as e:
+        mode = Mode(path)
+        root.component += mode
+    assert str(
+        e.value) == '`mode` is required and `None` is not a valid value.`'
+
+    mode = Mode(path, mode='rwx------')
+    root.component += mode
+    assert mode.mode == 0o700
+
+    mode = Mode(path, mode='500')
+    root.component += mode
+    assert mode.mode == 0o500
 
 
 def test_mode_ensures_mode_for_directories(root):

--- a/src/batou/lib/tests/test_file.py
+++ b/src/batou/lib/tests/test_file.py
@@ -839,7 +839,9 @@ def test_mode_verifies_for_nonexistent_file(root):
         mode.verify()
 
 
-def test_mode_ensures_mode_for_files(root):
+@pytest.mark.parametrize('input,expected', [
+    (0o777, 0o777),])
+def test_mode_ensures_mode_for_files(root, input, expected):
     path = "path"
     open("work/mycomponent/" + path, "w").close()
     mode = Mode(path, mode=0o000)

--- a/src/batou/tests/fixture/basic_service/components/zeo/component.py
+++ b/src/batou/tests/fixture/basic_service/components/zeo/component.py
@@ -3,6 +3,6 @@ from batou.component import Component, Attribute
 
 class ZEO(Component):
 
-    port = Attribute(int, "9001")
+    port = Attribute(int, default_conf_string="9001")
 
     features = ["test", "test2"]

--- a/src/batou/tests/test_deploy.py
+++ b/src/batou/tests/test_deploy.py
@@ -39,6 +39,14 @@ ERROR: Failed loading component file
       File: .../examples/errors/components/component6/component.py
  Exception: No module named 'asdf'
 
+ERROR: Failed loading component file
+      File: .../examples/errors/components/component7/component.py
+ Exception: Attributes only support one of those parameters: `default` or `default_conf_string`.
+
+ERROR: Missing component
+ Component: component7
+      Host: localhost
+
 ERROR: Missing component
  Component: missingcomponent
       Host: localhost

--- a/src/batou/tests/test_deploy.py
+++ b/src/batou/tests/test_deploy.py
@@ -41,7 +41,7 @@ ERROR: Failed loading component file
 
 ERROR: Failed loading component file
       File: .../examples/errors/components/component7/component.py
- Exception: Attributes only support one of those parameters: `default` or `default_conf_string`.
+ Exception: Attributes only support one of those parameters: either `default` or `default_conf_string`.
 
 ERROR: Missing component
  Component: component7

--- a/src/batou/tests/test_endtoend.py
+++ b/src/batou/tests/test_endtoend.py
@@ -34,6 +34,14 @@ ERROR: Failed loading component file
       File: .../examples/errors/components/component6/component.py
  Exception: No module named 'asdf'
 
+ERROR: Failed loading component file
+      File: .../examples/errors/components/component7/component.py
+ Exception: Attributes only support one of those parameters: `default` or `default_conf_string`.
+
+ERROR: Missing component
+ Component: component7
+      Host: localhost
+
 ERROR: Missing component
  Component: missingcomponent
       Host: localhost

--- a/src/batou/tests/test_endtoend.py
+++ b/src/batou/tests/test_endtoend.py
@@ -87,6 +87,14 @@ ERROR: Failed loading component file
       File: .../examples/errors/components/component6/component.py
  Exception: No module named 'asdf'
 
+ERROR: Failed loading component file
+      File: .../examples/errors/components/component7/component.py
+ Exception: Attributes only support one of those parameters: `default` or `default_conf_string`.
+
+ERROR: Missing component
+ Component: component7
+      Host: localhost
+
 ERROR: Missing component
  Component: missingcomponent
       Host: localhost

--- a/src/batou/tests/test_endtoend.py
+++ b/src/batou/tests/test_endtoend.py
@@ -36,7 +36,7 @@ ERROR: Failed loading component file
 
 ERROR: Failed loading component file
       File: .../examples/errors/components/component7/component.py
- Exception: Attributes only support one of those parameters: `default` or `default_conf_string`.
+ Exception: Attributes only support one of those parameters: either `default` or `default_conf_string`.
 
 ERROR: Missing component
  Component: component7
@@ -89,7 +89,7 @@ ERROR: Failed loading component file
 
 ERROR: Failed loading component file
       File: .../examples/errors/components/component7/component.py
- Exception: Attributes only support one of those parameters: `default` or `default_conf_string`.
+ Exception: Attributes only support one of those parameters: either `default` or `default_conf_string`.
 
 ERROR: Missing component
  Component: component7


### PR DESCRIPTION
As Attributes are data descriptors it is not possible to get the conversion function from the attribute alone. We need to check on the parent component for it. This made it necessary to adapt code, which sets defaults and overrides on Attributes.

When this PR is merged, we need to adapt https://github.com/flyingcircusio/batou_ext.