### PR TITLE
Update bootstrap for new projects.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,7 +35,7 @@
 
   We provide a built-in plugin to support NixOS development containers
   that feel similar to the Flying Circus VM platform.
- 
+
 - Adapt `bootstrap.sh` to the use of appenv.
 
 2.3b1 (2021-05-21)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,8 @@
 
   We provide a built-in plugin to support NixOS development containers
   that feel similar to the Flying Circus VM platform.
+ 
+- Adapt `bootstrap.sh` to the use of appenv.
 
 2.3b1 (2021-05-21)
 ------------------

--- a/bootstrap
+++ b/bootstrap
@@ -17,7 +17,7 @@ mv requirements.txt.new requirements.txt
 ./appenv update-lockfile
 ./batou --help
 if [ -d ".git" ]; then
-	echo '.batou' >> .gitignore
-	git add .gitignore requirements.txt requirements.lock batou
+	echo '.appenv' >> .gitignore
+	git add .gitignore requirements.txt requirements.lock batou appenv
 fi
 }


### PR DESCRIPTION
The directory of the venv changed its name and we want to have `appenv` in the repo directly.