### PR TITLE
Update docs to appenv version

### DIFF
--- a/doc/source/upgrading.txt
+++ b/doc/source/upgrading.txt
@@ -121,6 +121,6 @@ After having switched from batou 1.x to 2.x you might update to the latest
     - If you want to use an unreleased version use a git URL like this:
       ``-e git+https://github.com/flyingcircusio/batou.git#egg=batou`` instead
       of the ``batou==2.x`` requirement.
-* Run ``./batou appenv-update-lockfile`` to update ``requirements.lock``.
+* Run ``./appenv update-lockfile`` to update ``requirements.lock``.
 * Commit the changes and run ``batou`` so it can update itself to the new
   version.


### PR DESCRIPTION
Update to the command needed when using the new `appenv` version.