### PR TITLE
re-192: Add flake8 to pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,7 @@ repos:
     hooks:
     -   id: yapf
         args: [-i, -p]
+-   repo: https://github.com/PyCQA/flake8
+    rev: 3.9.2
+    hooks:
+    -   id: flake8

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,7 +16,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../.."))
-from batou import __version__
+from batou import __version__  # noqa: E402 import not at top of file
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/examples/django/components/django/mysite/mysite/settings.py
+++ b/examples/django/components/django/mysite/mysite/settings.py
@@ -12,15 +12,15 @@ MANAGERS = ADMINS
 DATABASES = {
     "default": {
         "ENGINE":
-        "django.db.backends.",  # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
+        "django.db.backends.",  # Add 'postgresql_psycopg2', 'mysql', ...
         "NAME": "",  # Or path to database file if using sqlite3.
         # The following settings are not used with sqlite3:
         "USER": "",
         "PASSWORD": "",
         "HOST":
-        "",  # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
+        "",  # Empty for localhost through domain sockets or '127.0.0.1' ...
         "PORT": "",  # Set to empty string for default.
-    }}
+    }}  # noqa: E501 line too long
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
@@ -109,7 +109,8 @@ ROOT_URLCONF = "mysite.urls"
 WSGI_APPLICATION = "mysite.wsgi.application"
 
 TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
+    # Put strings here, like "/home/html/django_templates" or
+    # "C:/www/django/templates".
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
 )

--- a/examples/django/components/django/mysite/mysite/urls.py
+++ b/examples/django/components/django/mysite/mysite/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import patterns
 
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin

--- a/examples/django/components/django/mysite/mysite/wsgi.py
+++ b/examples/django/components/django/mysite/mysite/wsgi.py
@@ -24,7 +24,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
-from django.core.wsgi import get_wsgi_application
+from django.core.wsgi import get_wsgi_application  # noqa: E402 not at top
 
 application = get_wsgi_application()
 

--- a/examples/django/components/supervisor/component.py
+++ b/examples/django/components/supervisor/component.py
@@ -1,2 +1,2 @@
-from batou.lib.supervisor import Supervisor
-from batou.lib.nagios import NagiosServer
+from batou.lib.supervisor import Supervisor  # noqa: F401 import unused
+from batou.lib.nagios import NagiosServer  # noqa: F401 import unused

--- a/examples/errors/components/component6/component.py
+++ b/examples/errors/components/component6/component.py
@@ -1,1 +1,1 @@
-import asdf
+import asdf  # noqa: F401 import unused

--- a/examples/errors/components/crontab/component.py
+++ b/examples/errors/components/crontab/component.py
@@ -1,1 +1,1 @@
-from batou.lib.cron import CronTab
+from batou.lib.cron import CronTab  # noqa: F401 import unused

--- a/examples/errors2/components/crontab/component.py
+++ b/examples/errors2/components/crontab/component.py
@@ -1,1 +1,1 @@
-from batou.lib.cron import CronTab
+from batou.lib.cron import CronTab  # noqa: F401 import unused

--- a/examples/errors2/components/dnsproblem2/component.py
+++ b/examples/errors2/components/dnsproblem2/component.py
@@ -1,4 +1,4 @@
-from batou.component import Attribute, Component
+from batou.component import Component
 from batou.utils import Address
 
 

--- a/examples/tutorial-provision-container/appenv
+++ b/examples/tutorial-provision-container/appenv
@@ -20,7 +20,6 @@ import hashlib
 import http.client
 import os
 import os.path
-import shlex
 import shutil
 import subprocess
 import sys
@@ -30,12 +29,12 @@ import venv
 
 def cmd(c, merge_stderr=True, quiet=False):
     # TODO revisit the cmd() architecture w/ python 3
-    # XXX better IO management for interactive output and seeing original errors
-    # and output at appropriate places ...
+    # XXX better IO management for interactive output and seeing original
+    # errors and output at appropriate places ...
     try:
         kwargs = {"shell": True}
         if merge_stderr:
-            kwargs["stderr"] = stderr = subprocess.STDOUT
+            kwargs["stderr"] = subprocess.STDOUT
         return subprocess.check_output([c], **kwargs)
     except subprocess.CalledProcessError as e:
         print("{} returned with exit code {}".format(c, e.returncode))
@@ -74,8 +73,8 @@ def ensure_venv(target):
         # This is trying to detect whether we're on a proper Python stdlib
         # or on a broken Debian. See various StackOverflow questions about
         # this.
-        import distutils.util
-        import ensurepip
+        import distutils.util  # noqa: F401 imported but unused
+        import ensurepip  # noqa: F401 imported but unused
     except ImportError:
         # Okay, lets repair this, if we can. May need privilege escalation
         # at some point.
@@ -107,8 +106,8 @@ def ensure_venv(target):
                                  "python{}.{}".format(*sys.version_info[:2]),
                                  "site-packages", module))
 
-            # (always) prepend the site packages so we can actually have a fixed
-            # distutils installation.
+            # (always) prepend the site packages so we can actually have a
+            # fixed distutils installation.
             site_packages = os.path.abspath(
                 os.path.join(target, "lib", "python" + python_maj_min,
                              "site-packages"))
@@ -121,13 +120,59 @@ def ensure_venv(target):
 
     print("Ensuring pip ...")
     cmd("{target}/bin/python -m ensurepip --default-pip".format(target=target))
-    if python_maj_min == "3.4":
-        # Last version of Pip supporting Python 3.4
-        cmd('{target}/bin/python -m pip install --upgrade "pip<19.2"'.format(
-            target=target))
+    cmd("{target}/bin/python -m pip install --upgrade pip".format(
+        target=target))
+
+
+def ensure_minimal_python():
+    current_python = os.path.realpath(sys.executable)
+    preferences = None
+    if os.path.exists('requirements.txt'):
+        with open('requirements.txt') as f:
+            for line in f:
+                # Expected format:
+                # # appenv-python-preference: 3.1,3.9,3.4
+                if not line.startswith("# appenv-python-preference: "):
+                    continue
+                preferences = line.split(':')[1]
+                preferences = [x.strip() for x in preferences.split(',')]
+                preferences = list(filter(None, preferences))
+                break
+    if not preferences:
+        # We have no preferences defined, use the current python.
+        print("Update lockfile with with {}.".format(current_python))
+        print("If you want to use a different version, set it as via")
+        print(" `# appenv-python-preference:` in requirements.txt.")
+        return
+
+    preferences.sort(key=lambda s: [int(u) for u in s.split('.')])
+
+    for version in preferences[0:1]:
+        python = shutil.which("python{}".format(version))
+        if not python:
+            # not a usable python
+            continue
+        python = os.path.realpath(python)
+        if python == current_python:
+            # found a preferred python and we're already running as it
+            break
+        # Try whether this Python works
+        try:
+            subprocess.check_call([python, "-c", "print(1)"],
+                                  stdout=subprocess.DEVNULL,
+                                  stderr=subprocess.DEVNULL)
+        except subprocess.CalledProcessError:
+            continue
+
+        argv = [os.path.basename(python)] + sys.argv
+        os.environ["APPENV_BEST_PYTHON"] = python
+        os.execv(python, argv)
     else:
-        cmd("{target}/bin/python -m pip install --upgrade pip".format(
-            target=target))
+        print("Could not find the minimal preferred Python version.")
+        print("To ensure a working requirements.lock on all Python versions")
+        print("make Python {} available on this system.".format(
+            preferences[0]))
+        sys.exit(66)
 
 
 def ensure_best_python(base):
@@ -139,18 +184,20 @@ def ensure_best_python(base):
         return
     import shutil
 
-    with open('requirements.txt') as f:
-        for line in f:
-            # Expected format:
-            # # appenv-python-preference: 3.1,3.9,3.4
-            if not line.startswith("# appenv-python-preference: "):
-                continue
-            preferences = line.split(':')[1]
-            preferences = [x.strip() for x in preferences.split(',')]
-            preferences = list(filter(None, preferences))
-            break
-        else:
-            preferences = ['3.{}'.format(x) for x in reversed(range(4, 20))]
+    # use newest Python available if nothing else is requested
+    preferences = ['3.{}'.format(x) for x in reversed(range(4, 20))]
+
+    if os.path.exists('requirements.txt'):
+        with open('requirements.txt') as f:
+            for line in f:
+                # Expected format:
+                # # appenv-python-preference: 3.1,3.9,3.4
+                if not line.startswith("# appenv-python-preference: "):
+                    continue
+                preferences = line.split(':')[1]
+                preferences = [x.strip() for x in preferences.split(',')]
+                preferences = list(filter(None, preferences))
+                break
 
     current_python = os.path.realpath(sys.executable)
     for version in preferences:
@@ -241,8 +288,8 @@ class AppEnv(object):
         os.execv(cmd, argv)
 
     def _prepare(self):
-        # copy used requirements.txt into the target directory so we can use that
-        # to check later
+        # copy used requirements.txt into the target directory so we can use
+        # that to check later
         # - when to clean up old versions? keep like one or two old revisions?
         # - enumerate the revisions and just copy the requirements.txt, check
         #   for ones that are clean or rebuild if necessary
@@ -252,8 +299,8 @@ class AppEnv(object):
             env_dir = os.path.join(self.appenv_dir, 'unclean')
             ensure_venv(env_dir)
             print('Ensuring unclean install ...')
-            cmd('{env_dir}/bin/python -m pip install -r requirements.txt --upgrade'
-                .format(env_dir=env_dir))
+            cmd('{env_dir}/bin/python -m pip install -r requirements.txt'
+                ' --upgrade'.format(env_dir=env_dir))
         else:
             hash_content = []
             requirements = open("requirements.lock", "rb").read()
@@ -268,7 +315,7 @@ class AppEnv(object):
                 env_dir, os.path.join(self.appenv_dir, "unclean")])
             for path in glob.glob(
                     "{appenv_dir}/*".format(appenv_dir=self.appenv_dir)):
-                if not path in whitelist:
+                if path not in whitelist:
                     print(
                         "Removing expired path: {path} ...".format(path=path))
                     if not os.path.isdir(path):
@@ -276,10 +323,10 @@ class AppEnv(object):
                     else:
                         shutil.rmtree(path)
             if os.path.exists(env_dir):
-                # check whether the existing environment is OK, it might be nice
-                # to rebuild in a separate place if necessary to avoid interruptions
-                # to running services, but that isn't what we're using it for at the
-                # moment
+                # check whether the existing environment is OK, it might be
+                # nice to rebuild in a separate place if necessary to avoid
+                # interruptions to running services, but that isn't what we're
+                # using it for at the  moment
                 try:
                     if not os.path.exists(
                             "{env_dir}/appenv.ready".format(env_dir=env_dir)):
@@ -296,8 +343,8 @@ class AppEnv(object):
                     f.write(requirements)
 
                 print("Installing ...")
-                cmd("{env_dir}/bin/python -m pip install --no-deps -r {env_dir}/requirements.lock"
-                    .format(env_dir=env_dir))
+                cmd("{env_dir}/bin/python -m pip install --no-deps -r"
+                    " {env_dir}/requirements.lock".format(env_dir=env_dir))
 
                 cmd("{env_dir}/bin/python -m pip check".format(
                     env_dir=env_dir))
@@ -342,9 +389,9 @@ class AppEnv(object):
         with open("requirements.txt", "w") as requirements_txt:
             requirements_txt.write(dependency + "\n")
         print()
-        print(
-            "Done. You can now `cd {}` and call `./{}` to bootstrap and run it."
-            .format(os.path.relpath(target, self.original_cwd), command))
+        print("Done. You can now `cd {}` and call"
+              " `./{}` to bootstrap and run it.".format(
+                  os.path.relpath(target, self.original_cwd), command))
 
     def python(self, args, remaining):
         self.run('python', remaining)
@@ -359,6 +406,7 @@ class AppEnv(object):
         cmd("rm -rf {appenvdir}".format(appenvdir=self.appenv_dir))
 
     def update_lockfile(self, args=None, remaining=None):
+        ensure_minimal_python()
         os.chdir(self.base)
         print("Updating lockfile")
         tmpdir = os.path.join(self.appenv_dir, "updatelock")
@@ -371,8 +419,9 @@ class AppEnv(object):
 
         # Hack because we might not have pkg_resources, but the venv should
         tmp_paths = cmd(
-            "{tmpdir}/bin/python -c 'import sys; print(\"\\n\".join(sys.path))'"
-            .format(tmpdir=tmpdir),
+            "{tmpdir}/bin/python -c"
+            " 'import sys; print(\"\\n\".join(sys.path))'".format(
+                tmpdir=tmpdir),
             merge_stderr=False).decode(sys.getfilesystemencoding())
         for line in tmp_paths.splitlines():
             line = line.strip()
@@ -397,6 +446,9 @@ class AppEnv(object):
             for line in f.readlines():
                 if line.strip().startswith('-e '):
                     extra_specs.append(line.strip())
+                    continue
+                # filter comments, in particular # appenv-python-preferences
+                if line.strip().startswith('#'):
                     continue
                 spec = list(pkg_resources.parse_requirements(line))[0]
                 requested_versions[spec.project_name] = spec
@@ -426,8 +478,8 @@ def main():
 
     ensure_best_python(base)
     # clear PYTHONPATH variable to get a defined environment
-    # XXX this is a bit of history. not sure whether its still needed. keeping it
-    # for good measure
+    # XXX this is a bit of history. not sure whether its still needed. keeping
+    # it for good measure
     if "PYTHONPATH" in os.environ:
         del os.environ["PYTHONPATH"]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,13 @@ split_before_expression_after_opening_paren = true
 split_before_closing_bracket = false
 SPACE_BETWEEN_ENDING_COMMA_AND_CLOSING_BRACKET = false
 BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF = true
+
+[flake8]
+ignore =
+    # Missing whitespace after ',', ';', or ':' -- enforced by yapf config
+    E231
+    # Line break occurred before a binary operator -- enforced by yapf config
+    W503
+    # Line break occurred after a binary operator -- enforced by yapf config
+    W504
+max-line-length = 80

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,6 @@
 and deployments.
 """
 
-import glob
-import os.path
-
 from setuptools import find_packages, setup
 
 version = open("src/batou/version.txt").read().strip()

--- a/src/batou/__init__.py
+++ b/src/batou/__init__.py
@@ -40,7 +40,8 @@ class GPGCallError(ReportingException):
         self.output = output.decode('ascii', errors='replace')
 
     def __str__(self):
-        return f"Exitcode {self.exitcode} while calling: {self.command}\n{self.output}"
+        return (f"Exitcode {self.exitcode}"
+                f" while calling: {self.command}\n{self.output}")
 
     def report(self):
         output.error('Error while calling GPG')

--- a/src/batou/deploy.py
+++ b/src/batou/deploy.py
@@ -6,11 +6,10 @@ import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
 
-from batou import (ConfigurationError, DeploymentError, FileLockedError,
-                   ReportingException, SilentConfigurationError)
+from batou import ReportingException, SilentConfigurationError
 from batou._output import TerminalBackend, output
 
-from .environment import Environment, MissingEnvironment
+from .environment import Environment
 from .utils import locked, notify, self_id
 
 

--- a/src/batou/fixtures.py
+++ b/src/batou/fixtures.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 
 import batou.utils
 import pytest

--- a/src/batou/lib/file.py
+++ b/src/batou/lib/file.py
@@ -297,7 +297,6 @@ def limited_buffer(iterator, limit, lead, separator="...", logdir="/tmp"):
     # Fill the remainder into the end buffer but only keep lead size.
     # This is a memory optimization: don't ever keep the whole iterator in
     # memory!
-    started_logging = False
     end_buffer = []
     _, diff_log = tempfile.mkstemp(suffix=".diff", dir=logdir)
     diff_log_file = open(diff_log, "a+")

--- a/src/batou/remote_core.py
+++ b/src/batou/remote_core.py
@@ -389,7 +389,7 @@ if __name__ == "__channelexec__":
 
             environment = deployment.environment
             if exception not in environment.exceptions:
-                environment.exceptions.append(e)
+                environment.exceptions.append(exception)
 
             environment.exceptions = list(
                 filter(lambda e: not isinstance(e, SilentConfigurationError),

--- a/src/batou/secrets/edit.py
+++ b/src/batou/secrets/edit.py
@@ -1,5 +1,4 @@
 """Securely edit encrypted secret files."""
-import glob
 import os
 import subprocess
 import sys

--- a/src/batou/secrets/encryption.py
+++ b/src/batou/secrets/encryption.py
@@ -5,7 +5,6 @@ import fcntl
 import glob
 import io
 import os
-import shlex
 import subprocess
 import tempfile
 

--- a/src/batou/secrets/manage.py
+++ b/src/batou/secrets/manage.py
@@ -1,7 +1,6 @@
 """Summarize status of secret files."""
 
 from .encryption import EncryptedConfigFile
-from batou import ConfigurationError
 from batou import GPGCallError
 import glob
 import os.path

--- a/src/batou/secrets/tests/test_secrets.py
+++ b/src/batou/secrets/tests/test_secrets.py
@@ -61,8 +61,6 @@ def test_decrypt_missing_key(monkeypatch):
 
     with pytest.raises(batou.GPGCallError):
         EncryptedConfigFile(encrypted_file)
-        f = secrets.__enter__()
-        f.read()
 
 
 def test_write_should_fail_unless_write_locked():

--- a/src/batou/tests/test_config.py
+++ b/src/batou/tests/test_config.py
@@ -6,7 +6,6 @@ import pytest
 from batou import MissingEnvironment
 from batou.component import Component
 from batou.environment import Environment
-from batou.host import Host
 
 
 def test_parse_nonexisting_environment_raises_error(tmpdir):

--- a/src/batou/tests/test_endtoend.py
+++ b/src/batou/tests/test_endtoend.py
@@ -282,4 +282,4 @@ localhost > Hello > File('work/hello/other-secrets.yaml') > Content('other-secre
 Not showing diff as it contains sensitive data,
 see ...diff for the diff.
 ============================= DEPLOYMENT FINISHED ==============================
-""")
+""")  # noqa: E501 line too long

--- a/src/batou/tests/test_host.py
+++ b/src/batou/tests/test_host.py
@@ -1,7 +1,7 @@
 import mock
 import pytest
 
-from ..host import Host, RPCWrapper
+from ..host import RPCWrapper
 
 
 def test_rpcwrapper_returns_result():

--- a/src/batou/tests/test_remote.py
+++ b/src/batou/tests/test_remote.py
@@ -37,7 +37,6 @@ def test_remotehost_start(sample_service):
     env = Environment("test-with-env-config")
     env.load()
     env.configure()
-    d = Deployment(env, platform="", jobs=1, timeout=30, dirty=False)
     h = RemoteHost("asdf", env)
     h.connect = mock.Mock()
     h.rpc = mock.Mock()

--- a/src/batou/tests/test_remote_core.py
+++ b/src/batou/tests/test_remote_core.py
@@ -102,7 +102,7 @@ def test_build_batou_virtualenv_exists(mock_remote_core, tmpdir):
     remote_core.ensure_repository(str(tmpdir), "hg-pull")
     remote_core.ensure_base("asdf")
     os.mkdir(remote_core.target_directory + "/bin")
-    with open(remote_core.target_directory + "/bin/python3", "w") as f:
+    with open(remote_core.target_directory + "/bin/python3", "w"):
         # Break python
         pass
     remote_core.build_batou()

--- a/src/batou/tests/test_repository.py
+++ b/src/batou/tests/test_repository.py
@@ -14,11 +14,11 @@ def test_repository_hg_norepo(tmpdir):
     environment.base_dir = tmpdir
     os.chdir(tmpdir)
 
-    with pytest.raises(batou.utils.CmdExecutionError) as e:
+    with pytest.raises(batou.utils.CmdExecutionError):
         MercurialRepository(environment)
 
     subprocess.check_call(['hg', 'init'])
-    repository = MercurialRepository(environment)
+    MercurialRepository(environment)
 
 
 def test_repository_hg_show_upstream(tmpdir):
@@ -35,7 +35,7 @@ def test_repository_hg_show_upstream(tmpdir):
     repository._upstream = None
 
     environment.repository_url = None
-    with pytest.raises(batou.utils.CmdExecutionError) as e:
+    with pytest.raises(batou.utils.CmdExecutionError):
         repository.upstream
 
     with open('.hg/hgrc', 'w') as f:
@@ -44,7 +44,7 @@ def test_repository_hg_show_upstream(tmpdir):
 foobar = 1234
 """)
 
-    with pytest.raises(AssertionError) as e:
+    with pytest.raises(AssertionError):
         repository.upstream
 
     with open('.hg/hgrc', 'w') as f:
@@ -124,7 +124,8 @@ def test_repository_hg_ship_verify_after_ship(tmpdir):
     repository._ship = no_ship
 
     host = mock.Mock()
-    host.rpc.hg_update_working_copy.return_value = '0000000000000000000000000000000000000000'
+    host.rpc.hg_update_working_copy.return_value = (
+        '0000000000000000000000000000000000000000')
     repository.update(host)
 
     with open('asdf', 'w') as f:

--- a/src/batou/tests/test_utils.py
+++ b/src/batou/tests/test_utils.py
@@ -58,9 +58,9 @@ def test_resolve_v6_does_not_return_link_local_addresses(output, monkeypatch):
 
     monkeypatch.setattr(socket, 'getaddrinfo', link_local_addrinfo)
 
-    with pytest.raises(ValueError) as f:
+    with pytest.raises(ValueError) as err:
         resolve_v6("foo.example.com", 80)
-    assert 'No valid address found for `foo.example.com`.'
+    assert 'No valid address found for `foo.example.com`.' == str(err.value)
 
     def link_local_addrinfo(*args, **kw):
         return [(None, None, None, None, ('fe80::feaa:14ff:fe8f:94ba', 80,
@@ -76,7 +76,7 @@ def test_resolve_v6_does_not_return_link_local_addresses(output, monkeypatch):
 resolving (v6) `foo.example.com` (getaddrinfo)
 resolved (v6) `foo.example.com` to [(None, None, None, None, ('fe80::feaa:14ff:fe8f:94ba', 80, None, None)), (None, None, None, None, ('2a02::1', 80, None, None))]
 selected 2a02::1
-""" == output.backend.output
+""" == output.backend.output  # noqa: E501 line too long
 
 
 def test_address_without_implicit_or_explicit_port_fails():

--- a/src/batou/utils.py
+++ b/src/batou/utils.py
@@ -108,7 +108,7 @@ def resolve(host, port=0, resolve_override=resolve_override):
         responses = socket.getaddrinfo(host, int(port), socket.AF_INET)
         output.annotate('resolved `{}` to {}'.format(host, responses))
         address = responses[0][4][0]
-        output.annotate('selected '.format(host, address))
+        output.annotate('selected {}, {}'.format(host, address))
     return address
 
 


### PR DESCRIPTION
Adapted the code, fixed some errors `flake8` found.
Tested with `pre-commit run -a` and `tox -epre-commit`.

I was unable to find an example where `pyflakes` is used stand-alone, so I decided to use `flake8` and configure it in a way it can work together with the way `yapf` is currently configured.

Fixes #192.