### PR TITLE
output: different success colors for deploy/consistency/prediction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,12 +15,17 @@
   `provision.nix` to the container, but if you do then we avoid doing it
   twice.
 
-* Warn if neither `provision.nix` nor provision.sh are given as that seems more
+- Warn if neither `provision.nix` nor provision.sh are given as that seems more
   of an accident (like misspelling the filenames).
 
-* Continue deployments on failure when running `fc-manage` during provisioning
+- Continue deployments on failure when running `fc-manage` during provisioning
   but be more explicit about errors and warn the user that something maybe be
   fishy in the deployment subsequently.
+
+- Use different colors for success depending on whether you ran a real
+  deployment, a consistency check, or a predition.
+  (https://github.com/flyingcircusio/batou/issues/209)
+
 
 2.3b2 (2021-10-05)
 ------------------

--- a/src/batou/deploy.py
+++ b/src/batou/deploy.py
@@ -234,11 +234,14 @@ def main(environment, platform, timeout, dirty, consistency_only, predict_only,
         'load', 'provision', 'connect', 'configure', 'deploy', 'summarize']
     if consistency_only:
         ACTION = "CONSISTENCY CHECK"
+        SUCCESS_FORMAT = {'cyan': True}
         STEPS.remove('deploy')
     elif predict_only:
         ACTION = "DEPLOYMENT PREDICTION"
+        SUCCESS_FORMAT = {'purple': True}
     else:
         ACTION = "DEPLOYMENT"
+        SUCCESS_FORMAT = {'green': True}
     with locked(".batou-lock"):
         deployment = Deployment(environment, platform, timeout, dirty, jobs,
                                 predict_only, provision_rebuild)
@@ -285,5 +288,5 @@ def main(environment, platform, timeout, dirty, consistency_only, predict_only,
 
         finally:
             deployment.disconnect()
-        output.section("{} FINISHED".format(ACTION), green=True)
+        output.section("{} FINISHED".format(ACTION), **SUCCESS_FORMAT)
         notify("{} SUCCEEDED".format(ACTION), environment.name)


### PR DESCRIPTION
We used to always give a green bar but being able to quickly tell
whether the success was about an actual deployment or a prediction
seems helpful.

Fixes #209