### PR TITLE
provisioning/devhost: a bundle of improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,18 @@
 - Require defaults to be explicitly declared for `Attribute`.
   ([#237](https://github.com/flyingcircusio/batou/issues/237))
 
+- Automatically pick up `provision.sh` and/or `provision.nix`.
+
+  You do not need to explicitly define a COPY command to copy the
+  `provision.nix` to the container, but if you do then we avoid doing it
+  twice.
+
+* Warn if neither `provision.nix` nor provision.sh are given as that seems more
+  of an accident (like misspelling the filenames).
+
+* Continue deployments on failure when running `fc-manage` during provisioning
+  but be more explicit about errors and warn the user that something maybe be
+  fishy in the deployment subsequently.
 
 2.3b2 (2021-10-05)
 ------------------

--- a/examples/tutorial-provision-container/environments/dev/environment.cfg
+++ b/examples/tutorial-provision-container/environments/dev/environment.cfg
@@ -14,4 +14,5 @@ provision-aliases =
 [provisioner:default]
 method = fc-nixos-dev-container
 host = largo.fcdev.fcio.net
-channel = https://hydra.flyingcircus.io/build/101493/download/1/nixexprs.tar.xz
+# 21.05 production release 2021_038
+channel = https://hydra.flyingcircus.io/channel/custom/platform-prs/pr-431/release

--- a/examples/tutorial-provision-container/environments/dev/provision.sh
+++ b/examples/tutorial-provision-container/environments/dev/provision.sh
@@ -1,2 +1,1 @@
-COPY provision.nix /etc/local/nixos/provision-container.nix
 ECHO $COMPONENT_HELLO_PASSWORD /etc/local/nixos/mysql-root-password


### PR DESCRIPTION
* automatically pick up either provision.sh and/or provision.nix
  (no need to define a COPY command for provision nix any longer)
* warn if neither provision.nix nor provision.sh are given
* continue deployments on failure during provisioning fc-manage
  but be more explicit about warning that something is fishy.