### PR TITLE
Fix use of `File` to sync a directory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,8 @@
 
 - Check python venvs for functional `pip`.
 
+- Fix use of `File` to sync a directory.
+
 
 2.3b3 (2021-11-30)
 ------------------

--- a/src/batou/lib/file.py
+++ b/src/batou/lib/file.py
@@ -105,7 +105,7 @@ class File(Component):
                         guess_source, self._unmapped_path
                     )
                 )
-        if self.content or self.source:
+        if self.ensure == "file" and (self.content or self.source):
             if self.template_args is None:
                 self.template_args = dict()
             if not self.template_context:

--- a/src/batou/lib/tests/test_file.py
+++ b/src/batou/lib/tests/test_file.py
@@ -1032,6 +1032,16 @@ def test_directory_copies_all_files(root):
 
 
 @pytest.mark.slow
+def test_directory_file_copies_all_files(root):
+    os.mkdir("source")
+    open("source/one", "w").close()
+    open("source/two", "w").close()
+    root.component += File("target", ensure="directory", source="source")
+    root.component.deploy()
+    assert sorted(os.listdir("work/mycomponent/target")) == ["one", "two"]
+
+
+@pytest.mark.slow
 def test_directory_last_updated_reflects_file_changes(root):
     os.mkdir("source")
     open("source/one", "w").close()


### PR DESCRIPTION
The following *should* have worked before to sync a directory but didn't:

```python
        self += File("dest",
            ensure="directory",
            source="source)
```