### PR TITLE
Showing usage messages for subcommands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,9 @@
   or strings that will be expanded, mapped and converted has been changed again
   to simplify the mechanics and make migration errors easier to understand.
 
+- Output usage strings for subcommands, instead of just the main command.
+
+
 ### Bug fixes
 
 - Check python venvs for functional `pip`.

--- a/src/batou/main.py
+++ b/src/batou/main.py
@@ -26,6 +26,8 @@ def main(args: Optional[list] = None) -> None:
         ).format(version),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+    parser.set_defaults(func=parser.print_usage)
+
     parser.add_argument(
         "-d", "--debug", action="store_true", help="Enable debug mode."
     )
@@ -34,6 +36,8 @@ def main(args: Optional[list] = None) -> None:
 
     # Deploy
     p = subparsers.add_parser("deploy", help="Deploy an environment.")
+    p.set_defaults(func=p.print_usage)
+
     p.add_argument(
         "-p",
         "--platform",
@@ -99,6 +103,8 @@ def main(args: Optional[list] = None) -> None:
             configured correctly. """
         ),
     )
+    secrets.set_defaults(func=secrets.print_usage)
+
     sp = secrets.add_subparsers()
 
     p = sp.add_parser(
@@ -111,6 +117,8 @@ def main(args: Optional[list] = None) -> None:
         """
         ),
     )
+    p.set_defaults(func=p.print_usage)
+
     p.add_argument(
         "--editor",
         "-e",
@@ -136,6 +144,7 @@ def main(args: Optional[list] = None) -> None:
     p = sp.add_parser(
         "add", help="Add a user's key to one or more secret files."
     )
+    p.set_defaults(func=p.print_usage)
     p.add_argument("keyid", help="The user's key ID or email address")
     p.add_argument(
         "--environments",
@@ -147,6 +156,7 @@ def main(args: Optional[list] = None) -> None:
     p = sp.add_parser(
         "remove", help="Remove a user's key from one or more secret files."
     )
+    p.set_defaults(func=p.print_usage)
     p.add_argument("keyid", help="The user's key ID or email address")
     p.add_argument(
         "--environments",
@@ -166,6 +176,7 @@ def main(args: Optional[list] = None) -> None:
         """
         ),
     )
+    migrate.set_defaults(func=migrate.print_usage)
     migrate.add_argument(
         "--bootstrap",
         default=False,
@@ -180,15 +191,15 @@ def main(args: Optional[list] = None) -> None:
     batou.output.enable_debug = args.debug
 
     # Pass over to function
-    func_args = dict(args._get_kwargs())
-    if "func" not in func_args:
-        parser.print_usage()
+    if args.func.__name__ == "print_usage":
+        args.func()
         sys.exit(1)
 
     if args.func != batou.migrate.main:
         output.backend = TerminalBackend()
         batou.migrate.assert_up_to_date()
 
+    func_args = dict(args._get_kwargs())
     del func_args["func"]
     del func_args["debug"]
     try:

--- a/src/batou/tests/test_main.py
+++ b/src/batou/tests/test_main.py
@@ -22,3 +22,26 @@ def test_main__main__2(tmp_path, monkeypatch, capsys):
     with mock.patch("batou.migrate.main", spec=True) as migrate_main:
         main(["migrate", "--bootstrap"])
     migrate_main.assert_called_with(bootstrap=True)
+
+
+def test_main__main__3(tmp_path, monkeypatch, capsys):
+    """It has useful usage-message if no arguments are given."""
+    monkeypatch.setenv("APPENV_BASEDIR", str(tmp_path))
+    calling_args = [
+        [],
+        ["deploy"],
+        ["secrets"],
+        ["secrets", "edit"],
+        ["secrets", "add"],
+        ["secrets", "remove"],
+    ]
+    for args in calling_args:
+        joined = " ".join(args)
+        with pytest.raises(SystemExit):
+            main(args)
+        # should contain "usage:"
+        # should contain joined as "usage: <joined> other_stuff"
+        std = capsys.readouterr()
+        output = std.out if std.out else std.err
+        assert output.startswith("usage:")
+        assert joined in output


### PR DESCRIPTION
Usage messages for subcommands were not previously displayed when typing them without arguments

This changes that.

Try:

```bash
$ ./batou secrets
usage: batou secrets [-h] {edit,summary,add,remove} ...
```