### PR TITLE
utils/Address: improve the dual stack resolver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,16 @@
 2.3b5 (unreleased)
 ------------------
 
+- Revise the new Address require_v4/require_v6 to allow environment-based
+  customization that can be used to revert back to the old settings.
+  ([#270](https://github.com/flyingcircusio/batou/issues/270))
+
 - Do not clobber git clones by default. Add new option `clobber` to allow
   specifying that a git clone may clobber the target directory.
   ([#298](https://github.com/flyingcircusio/batou/issues/298))
 
 - Add `checksum(value)` method to `Component` to easily compute sha256
-  checksums.
+  checksums. ([#232](https://github.com/flyingcircusio/batou/issues/232))
 
 
 2.3b4 (2022-08-22)

--- a/examples/django/.batou.json
+++ b/examples/django/.batou.json
@@ -1,1 +1,1 @@
-{"migration": {"version": 2302}}
+{"migration": {"version": 2303}}

--- a/examples/errors/.batou.json
+++ b/examples/errors/.batou.json
@@ -1,1 +1,1 @@
-{"migration": {"version": 2302}}
+{"migration": {"version": 2303}}

--- a/examples/errors2/.batou.json
+++ b/examples/errors2/.batou.json
@@ -1,1 +1,1 @@
-{"migration": {"version": 2302}}
+{"migration": {"version": 2303}}

--- a/examples/ignores/.batou.json
+++ b/examples/ignores/.batou.json
@@ -1,1 +1,1 @@
-{"migration": {"version": 2302}}
+{"migration": {"version": 2303}}

--- a/examples/largetempl/.batou.json
+++ b/examples/largetempl/.batou.json
@@ -1,1 +1,1 @@
-{"migration": {"version": 2302}}
+{"migration": {"version": 2303}}

--- a/examples/package/.batou.json
+++ b/examples/package/.batou.json
@@ -1,1 +1,1 @@
-{"migration": {"version": 2302}}
+{"migration": {"version": 2303}}

--- a/examples/sync_async/.batou.json
+++ b/examples/sync_async/.batou.json
@@ -1,1 +1,1 @@
-{"migration": {"version": 2302}}
+{"migration": {"version": 2303}}

--- a/examples/tutorial-component/.batou.json
+++ b/examples/tutorial-component/.batou.json
@@ -1,1 +1,1 @@
-{"migration": {"version": 2302}}
+{"migration": {"version": 2303}}

--- a/examples/tutorial-helloworld/.batou.json
+++ b/examples/tutorial-helloworld/.batou.json
@@ -1,1 +1,1 @@
-{"migration": {"version": 2302}}
+{"migration": {"version": 2303}}

--- a/examples/tutorial-parallelize/.batou.json
+++ b/examples/tutorial-parallelize/.batou.json
@@ -1,1 +1,1 @@
-{"migration": {"version": 2302}}
+{"migration": {"version": 2303}}

--- a/examples/tutorial-provision-container/.batou.json
+++ b/examples/tutorial-provision-container/.batou.json
@@ -1,1 +1,1 @@
-{"migration": {"version": 2302}}
+{"migration": {"version": 2303}}

--- a/examples/tutorial-secrets/.batou.json
+++ b/examples/tutorial-secrets/.batou.json
@@ -1,1 +1,1 @@
-{"migration": {"version": 2302}}
+{"migration": {"version": 2303}}

--- a/examples/vagrant-multi/.batou.json
+++ b/examples/vagrant-multi/.batou.json
@@ -1,1 +1,1 @@
-{"migration": {"version": 2302}}
+{"migration": {"version": 2303}}

--- a/examples/vagrant/.batou.json
+++ b/examples/vagrant/.batou.json
@@ -1,1 +1,1 @@
-{"migration": {"version": 2302}}
+{"migration": {"version": 2303}}

--- a/examples/venvs/.batou.json
+++ b/examples/venvs/.batou.json
@@ -1,1 +1,1 @@
-{"migration": {"version": 2302}}
+{"migration": {"version": 2303}}

--- a/src/batou/conftest.py
+++ b/src/batou/conftest.py
@@ -2,6 +2,8 @@ import os.path
 
 import pytest
 
+import batou.utils
+
 
 @pytest.fixture(autouse=True)
 def ensure_gpg_homedir(monkeypatch):
@@ -9,3 +11,10 @@ def ensure_gpg_homedir(monkeypatch):
         os.path.dirname(__file__), "secrets", "tests", "fixture", "gnupg"
     )
     monkeypatch.setitem(os.environ, "GNUPGHOME", home)
+
+
+@pytest.fixture(autouse=True)
+def reset_address_defaults():
+    v4, v6 = batou.utils.Address.require_v4, batou.utils.Address.require_v6
+    yield
+    batou.utils.Address.require_v4, batou.utils.Address.require_v6 = v4, v6

--- a/src/batou/environment.py
+++ b/src/batou/environment.py
@@ -1,3 +1,4 @@
+import ast
 import glob
 import json
 import os
@@ -95,6 +96,9 @@ class Environment(object):
     timeout = None
     target_directory = None
     jobs = None
+
+    require_v4 = True
+    require_v6 = False
 
     repository_url = None
     repository_root = None
@@ -246,6 +250,19 @@ class Environment(object):
             sandbox = config["vfs"]["sandbox"]
             sandbox = getattr(batou.vfs, sandbox)(self, config["vfs"])
             self.vfs_sandbox = sandbox
+
+        def parse_addr_option(value):
+            if value == "optional":
+                return value
+            return bool(ast.literal_eval(value))
+
+        for attr in ["require_v4", "require_v6"]:
+            if attr not in environment:
+                continue
+            setattr(self, attr, parse_addr_option(environment[attr]))
+
+        batou.utils.Address.require_v4 = self.require_v4
+        batou.utils.Address.require_v6 = self.require_v6
 
         if self.connect_method == "local":
             self.host_factory = LocalHost

--- a/src/batou/migrate/migrations/2300.py
+++ b/src/batou/migrate/migrations/2300.py
@@ -1,25 +1,5 @@
-from batou.utils import get_output
-
-
 def migrate(output):
     """Manual upgrade steps for 2.3."""
-    candidates = get_output(
-        'grep "Adddress" * -nIr | egrep -v "import"', "<no candidates found>"
-    )
-    output(
-        "Address objects now only resolve IPv4 addresses by default",
-        f"""
-
-If you use IPv6 then you have to enable it explicitly by setting
-`require_v6=True`.
-
-Candidates:
-
-{candidates}
-        """,
-        "manual",
-    )
-
     output(
         "Colliding attributes in environment and secrets",
         """

--- a/src/batou/migrate/migrations/2303.py
+++ b/src/batou/migrate/migrations/2303.py
@@ -1,0 +1,29 @@
+from batou.utils import get_output
+
+
+def migrate(output):
+    candidates = get_output(
+        'grep "Adddress" * -nIr | egrep -v "import"', "<no candidates found>"
+    )
+    output(
+        "Address objects now only resolve IPv4 addresses by default",
+        f"""
+
+        If you use IPv6 then you have to enable it explicitly by setting
+        `require_v6=True`. If you want the old behaviour you can use
+        `require_v6='optional'`.
+
+        You can also set new defaults per environment settings which allows
+        you to return to the previous behaviour of IPv6 being optional without
+        touching component code:
+
+        [environment]
+        require_v4 = True
+        require_v6 = optional
+
+        Candidates:
+
+        {candidates}
+        """,
+        "manual",
+    )

--- a/src/batou/migrate/migrations/tests/test_2300.py
+++ b/src/batou/migrate/migrations/tests/test_2300.py
@@ -9,6 +9,4 @@ step_2300 = importlib.import_module("batou.migrate.migrations.2300")
 def test_2300__migrate__1():
     """It informs about changes in Attribute, Address and secrets."""
     step_2300.migrate(output_migration_step)
-    expected = ["Address", "secrets"]
-    for term in expected:
-        assert term in batou.output.backend.output
+    assert "secrets" in batou.output.backend.output

--- a/src/batou/tests/fixture/sample_service/environments/test-with-env-config/environment.cfg
+++ b/src/batou/tests/fixture/sample_service/environments/test-with-env-config/environment.cfg
@@ -4,6 +4,9 @@ service_user = joe
 host_domain = example.com
 branch = release
 
+require_v6 = True
+require_v4 = optional
+
 [host:foo1]
 service_user = bob
 components = hello

--- a/src/batou/tests/test_environment.py
+++ b/src/batou/tests/test_environment.py
@@ -22,6 +22,9 @@ def test_load_should_use_defaults(sample_service):
 
 
 def test_load_should_use_config(sample_service):
+    assert batou.utils.Address.require_v6 is False
+    assert batou.utils.Address.require_v4 is True
+
     e = Environment("test-with-env-config")
     e.load()
     assert e.service_user == "joe"
@@ -29,6 +32,14 @@ def test_load_should_use_config(sample_service):
     assert e.branch == "release"
 
     assert e.hosts["foo1"].service_user == "bob"
+
+    # The keys were loaded into the environment
+    assert e.require_v6 is True
+    assert e.require_v4 == "optional"
+
+    # The class-based defaults were adapted
+    assert batou.utils.Address.require_v6 is True
+    assert batou.utils.Address.require_v4 == "optional"
 
 
 def test_load_ignores_predefined_environment_settings(sample_service):

--- a/src/batou/utils.py
+++ b/src/batou/utils.py
@@ -166,6 +166,9 @@ def resolve_v6(host, port=0, resolve_override=resolve_v6_override):
     return address
 
 
+ADDR_DEFAULT = object()  # sentinel
+
+
 @functools.total_ordering
 class Address(object):
     """An internet service address that can be listened and connected to.
@@ -181,19 +184,38 @@ class Address(object):
         >>> str(x.listen)
         '127.0.0.1:80'
 
+    You can specify which IP versions are expected to be resolved for listen
+    addresses in three ways with the require_v4/require_v6 flags:
+
+    * False -> this version must not be used
+    * True -> this version must be resolved properly
+    * 'optional' -> the listen/listen_v6 attribute will contain None if it does
+       not resolve.
+
     """
 
     #: The connect address as it should be used when configuring clients.
     #: This is a :py:class:`batou.utils.NetLoc` object.
     connect = None
 
-    require_v4 = False
+    # The dance with the ADDR_DEFAULT is to allow overriding the class-based
+    # defaults on an environment level.
+    require_v4 = True
     require_v6 = False
 
     def __init__(
-        self, connect_address, port=None, require_v4=True, require_v6=False
+        self,
+        connect_address,
+        port=None,
+        require_v4=ADDR_DEFAULT,
+        require_v6=ADDR_DEFAULT,
     ):
-        if not require_v4 and not require_v6:
+        if require_v4 is not ADDR_DEFAULT:
+            self.require_v4 = require_v4
+        if require_v6 is not ADDR_DEFAULT:
+            self.require_v6 = require_v6
+
+        if not self.require_v4 and not self.require_v6:
             raise ValueError(
                 "At least one of `require_v4` or `require_v6` is required. "
                 "None were selected."
@@ -204,15 +226,7 @@ class Address(object):
             connect = connect_address
         if port is None:
             raise ValueError("Need port for service address.")
-        self.connect = NetLoc(connect, str(port))
-        if require_v4:
-            address = resolve(connect, port)
-            self.listen = NetLoc(address, str(port))
-            self.require_v4 = True
-        if require_v6:
-            address = resolve_v6(connect, port)
-            self.listen_v6 = NetLoc(address, str(port))
-            self.require_v6 = True
+        self.connect = NetLoc(connect, port)
 
     def __lt__(self, other):
         if isinstance(other, Address):
@@ -234,14 +248,24 @@ class Address(object):
         object. It raises an :py:class:`batou.IPAddressConfigurationError`
         if used unconfigured.
         """
-        try:
-            return self._listen
-        except AttributeError:
+        if not self.require_v4:
             raise IPAddressConfigurationError(self, 4)
+
+        if not hasattr(self, "_listen_v4"):
+            try:
+                address = resolve(self.connect.host, self.connect.port)
+                self.listen = NetLoc(address, self.connect.port)
+            except Exception:
+                if self.require_v4 == "optional":
+                    self.listen = None
+                else:
+                    raise
+
+        return self._listen_v4
 
     @listen.setter
     def listen(self, value):
-        self._listen = value
+        self._listen_v4 = value
 
     @property
     def listen_v6(self):
@@ -250,10 +274,20 @@ class Address(object):
         object. It raises an :py:class:`batou.IPAddressConfigurationError`
         if used unconfigured.
         """
-        try:
-            return self._listen_v6
-        except AttributeError:
+        if not self.require_v6:
             raise IPAddressConfigurationError(self, 6)
+
+        if not hasattr(self, "_listen_v6"):
+            try:
+                address = resolve_v6(self.connect.host, self.connect.port)
+                self.listen_v6 = NetLoc(address, self.connect.port)
+            except Exception:
+                if self.require_v6 == "optional":
+                    self.listen_v6 = None
+                else:
+                    raise
+
+        return self._listen_v6
 
     @listen_v6.setter
     def listen_v6(self, value):


### PR DESCRIPTION
This allows a ternary option for required/unwanted/optional to deal more cleanly with different situations.

We also allow switching the per-environment default from v4=True/v6=False back to v4=True/v6=optional to avoid having to rewrite older environments that rely on this while still introducing new projects to the new settings by default and also suggesting that others should upgrade eventually.

Fixes #270