### PR TITLE
appenv: decode command output as unicode by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         exclude: "src/batou/insecure-private.key"
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/appenv.py
+++ b/appenv.py
@@ -38,8 +38,8 @@ def cmd(c, merge_stderr=True, quiet=False):
         return subprocess.check_output([c], **kwargs)
     except subprocess.CalledProcessError as e:
         print("{} returned with exit code {}".format(c, e.returncode))
-        print(e.output.decode("ascii"))
-        raise ValueError(e.output.decode("ascii"))
+        print(e.output.decode("utf-8", "replace"))
+        raise ValueError(e.output.decode("utf-8", "replace"))
 
 
 def get(host, path, f):


### PR DESCRIPTION
closes #350 

Chose to "replace", instead of for example "ignore" such that unknown characters are shown, but not swallowed.