### PR TITLE
Fix checkout of tags

### DIFF
--- a/src/batou/lib/git.py
+++ b/src/batou/lib/git.py
@@ -162,6 +162,7 @@ class Clone(Component):
                     self.expand("git reset --hard origin/{{component.branch}}")
                 )
             elif self.tag:
+                self.cmd(self.expand("git fetch --tags"))
                 self.cmd(self.expand("git reset --hard {{component.tag}}"))
             else:
                 self.cmd(self.expand("git reset --hard {{component.revision}}"))


### PR DESCRIPTION
Sometimes it is necessary to explicitely call `git fetch --tags` to get all
available tags before one can switch to the desired tag.
