### PR TITLE
provisioning: properly catch documented errors for `getaddrinfo`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 ## 2.4rc2 (unreleased)
 ----------------------
 
-- Nothing changed yet.
+- Fix bug where some rare exceptions (caused by DNS resolvers during provisioning)
+  bubbled incorrectly and caused spurious deployment errors.
 
 
 ## 2.4rc1 (2023-09-12)

--- a/src/batou/provision.py
+++ b/src/batou/provision.py
@@ -118,7 +118,10 @@ Host {hostname} {aliases}
                     f" alias override v4 {alias_fqdn} -> {addr}", debug=True
                 )
                 batou.utils.resolve_override[alias_fqdn] = addr
-        except (socket.gaierror, ValueError):
+        except (OSError, ValueError):
+            # We used to catch socket.gaierror here, but reading the
+            # docs correctly it can raise any OSError (and socket and gaierror
+            # are subclasses)
             pass
 
         try:
@@ -128,7 +131,10 @@ Host {hostname} {aliases}
                     f" alias override v6 {alias_fqdn} -> {addr}", debug=True
                 )
                 batou.utils.resolve_v6_override[alias_fqdn] = addr
-        except (socket.gaierror, ValueError):
+        except (OSError, ValueError):
+            # We used to catch socket.gaierror here, but reading the
+            # docs correctly it can raise any OSError (and socket and gaierror
+            # are subclasses)
             pass
 
     def summarize(self, host):


### PR DESCRIPTION
The gaierror is not the only possible error happening. According to docs we can end up with any OSError (or subclasses) and we should not fail deployments due to this. Seen this in the wild.

Test coverage currently not viable.