### PR TITLE
Bump PyYaml version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ pluggy==0.13.1
 pre-commit==2.15.0
 py==1.10.0
 pyparsing==2.4.7
-PyYAML==5.3.1
+PyYAML==6.0.1
 six==1.15.0
 toml==0.10.2
 tox==3.20.1


### PR DESCRIPTION
PyYAML was pulled down in https://github.com/flyingcircusio/batou/pull/382 to 5.3.1 due to a build related bug.

We need a PyYAML >5.4 because of https://github.com/advisories/GHSA-6757-jp84-gxfx
PyYAML==6.0.1 has the build bug fixed.