### PR TITLE
Add "rsync-ext" repository type which calls external rsync command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 - Fix bug where some rare exceptions (caused by DNS resolvers during provisioning)
   bubbled incorrectly and caused spurious deployment errors.
+- Add new `rsync-ext` repository type which uses an external rsync
+  binary for repository synchronisation.
 
 
 ## 2.4rc1 (2023-09-12)

--- a/doc/source/api/environment.txt
+++ b/doc/source/api/environment.txt
@@ -26,11 +26,12 @@ host_domain
     is handy do make the host/component assignment less verbose
 
 update_method
-    `hg-bundle|hg-pull|git-bundle|git-pull|rsync`, sets how the remote deployment repository is updated.
+    `hg-bundle|hg-pull|git-bundle|git-pull|rsync|rsync-ext`, sets how the remote deployment repository is updated.
 
     * `pull`, the default, uses `hg/git clone` and/or `hg/git pull` on the remote site.
     * `bundle` will copy the necessary changes as Mercurial/Git bundle, via the batou ssh link.
     * `rsync` will rsync the *working copy*. This is most useful in combination with the vagrant platform.
+    * `rsync-ext` is the same as `rsync`, except that it calls an external rsync binary instead of using the emulation in the Python `execnet` library.
 
 
 branch

--- a/doc/source/api/environment.txt
+++ b/doc/source/api/environment.txt
@@ -31,7 +31,7 @@ update_method
     * `pull`, the default, uses `hg/git clone` and/or `hg/git pull` on the remote site.
     * `bundle` will copy the necessary changes as Mercurial/Git bundle, via the batou ssh link.
     * `rsync` will rsync the *working copy*. This is most useful in combination with the vagrant platform.
-    * `rsync-ext` is the same as `rsync`, except that it calls an external rsync binary instead of using the emulation in the Python `execnet` library.
+    * `rsync-ext` is the same as `rsync`, except that it calls an external rsync binary instead of using the emulation in the Python `execnet` library. This is a drop-in replacement for `rsync`, with the exception that it handles deletion of files in the remote copy of the repository which no longer exist in the local copy.
 
 
 branch

--- a/doc/source/api/environment.txt
+++ b/doc/source/api/environment.txt
@@ -49,6 +49,11 @@ target_directory
         deployment repository is stored. Supports tilde expansion. Default:
         ``~/deployment``.
 
+require_sudo
+    Override the automatic detection of whether `sudo` is required to run
+    processes as the service user. If set to `True` then `sudo` will
+    always be used unconditionally. If set to `False` then `sudo` will
+    never be used.
 
 vfs mapping (TODO)
 ------------------

--- a/doc/source/user/quickstart.txt
+++ b/doc/source/user/quickstart.txt
@@ -778,8 +778,8 @@ integrity on the target systems. This consists of multiple steps:
    are the same.
 
 To leverage those features in batou, you have to select an update method in
-your environment that is not ``rsync``. batou supports ``git-pull``, ``git-
-bundle``, ``hg-pull`` and ``hg-bundle``.
+your environment that is not ``rsync`` or ``rsync-ext``. batou supports
+``git-pull``, ``git-bundle``, ``hg-pull`` and ``hg-bundle``.
 
 Lets use ``git-bundle`` for this example:
 

--- a/src/batou/environment.py
+++ b/src/batou/environment.py
@@ -90,6 +90,7 @@ class Environment(object):
     """
 
     service_user = None
+    require_sudo = None
     host_domain = None
     branch = None
     connect_method = None
@@ -251,6 +252,7 @@ class Environment(object):
         environment = config.get("environment", {})
         for key in [
             "service_user",
+            "require_sudo",
             "host_domain",
             "target_directory",
             "connect_method",

--- a/src/batou/remote_core.py
+++ b/src/batou/remote_core.py
@@ -229,7 +229,7 @@ def ensure_repository(target, method):
     elif method in ["git-pull", "git-bundle"]:
         if not os.path.exists(target + "/.git"):
             cmd("git init {}".format(target))
-    elif method == "rsync":
+    elif method in ["rsync", "rsync-ext"]:
         pass
     elif method == "local":
         pass


### PR DESCRIPTION
The existing `rsync` repository type uses execnet's emulation of rsync-like file synchronisation functionality in order to upload the repository to the remote system. However, execnet's implementation has some limitations, most notably that it does not synchronise deletions: files which are deleted in the local copy of the repository are not removed in the remote copy. This can cause surprising behaviour, for example when working with conditional inclusion in templated files.

This change introduces a new repository type, which I've called `rsync-ext` ("external rsync"), which invokes rsync as a subprocess in order to synchronise the local working copy of the repository with the remote system, instead of relying on execnet. rsync is invoked with the `--delete` flag, which means that files in the remote copy which do not correspond to the local copy are deleted, and with a list of exceptions so that local files related to e.g. version control and appenv are not synchronised.

This change also includes some changes to the handling of privilege escalation when connecting to a remote host as an intermediate step. batou automatically detects if the login user for a remote host is not the same as the deployment user, and invokes sudo as appropriate. Prior to this change, this was achieved using a shell snippet which gets executed on the remote system which prepends the sudo commands if a mismatch in login and deployment user is detected. As this is handled entirely on the remote system, this means that batou itself is unaware of whether privilege escalation was required.

I've replaced this shell snippet with logic within batou which calls the remote\_core to detect login/deployment user mismatches and then reconnects to the remote host in case of mismatch. Whether or not sudo is required is recorded in a class member, so that other parts of batou can use this information, and so the autodetection can be skipped for future connections. There is also a corresponding `require_sudo` environment configuration option to explicitly specify whether privilege escalation is required instead of relying on autodetection and a possible reconnection.

`rsync-ext` needs to ensure that the spawned rsync process invokes the appropriate command on the remote host if sudo is required. With the extended privilege escalation detection code, it only needs to read an object attribute and add the `--rsync-path` command if required.

I haven't been able to get the test suite working properly on my local machine to check for regressions, however I've manually tested these changes with a dummy deployment (using both `rsync-ext` and the remote sudo detection code), and everything appears to work correctly.