### PR TITLE
fix: SyncDirectory verification

### DIFF
--- a/src/batou/lib/file.py
+++ b/src/batou/lib/file.py
@@ -204,6 +204,9 @@ class SyncDirectory(Component):
         return " ".join("--exclude '{}'".format(x) for x in self.exclude) + " "
 
     def verify(self):
+        if not os.path.isdir(self.path):
+            raise batou.UpdateNeeded()
+
         stdout, stderr = self.cmd(
             "rsync {} {}{}/ {}".format(
                 self.verify_opts, self.exclude_arg, self.source, self.path

--- a/src/batou/lib/tests/test_file.py
+++ b/src/batou/lib/tests/test_file.py
@@ -23,6 +23,7 @@ from batou.lib.file import (
     Presence,
     Purge,
     Symlink,
+    SyncDirectory,
     YAMLContent,
     ensure_path_nonexistent,
 )
@@ -1144,3 +1145,11 @@ def test_purge_globs_and_deletes_files(root):
     root.component += Purge("sourc*")
     root.component.deploy()
     assert sorted(os.listdir("work/mycomponent")) == []
+
+
+def test_syncdirectory_needs_update_on_nonexisting_target(root):
+    os.mkdir("work/mycomponent/existing_dir")
+    open("work/mycomponent/existing_dir/test_file", "w").close()
+    with pytest.raises(batou.UpdateNeeded):
+        sd = SyncDirectory("non_existing_dir", source="existing_dir")
+        sd.verify()


### PR DESCRIPTION
Add a check to the SyncDirectory component for the target directory.

The SyncDirectory component's `verify()` stage fails when the target directory does not exist yet, because it uses rsync to determine if there is a diff between left and right. In cases where the target directory is part of the deployment and has thusly not been created yet this leads to unexpected errors.