### PR TITLE
Track component initialisations for error messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 -----------------------
 
 - batou migrate now writes .batou.json with a newline at the end as `pre-commit` hooks expect (usually).
+- Unused Components, that is, Components that are initialized, but not used in the deployment, are now reported as warnings.
 
 
 ## 2.5.0b2 (2024-05-15)

--- a/src/batou/__init__.py
+++ b/src/batou/__init__.py
@@ -482,16 +482,26 @@ class UnusedComponentsInitialized(ConfigurationError):
     def from_context(cls, components, root):
         self = cls()
         self.unused_components = []
+        self.breadcrumbs = []
         for component in components:
             self.unused_components.append(repr(component.__class__.__name__))
+            self.breadcrumbs.append(component._init_breadcrumbs)
         self.root_name = root.name
         return self
 
     def __str__(self):
-        return f"Unused components: {', '.join(self.unused_components)}"
+        out_str = "Unused components: "
+        for i, component in enumerate(self.unused_components):
+            out_str += f"\n    {component}: {' -> '.join(self.breadcrumbs[i])}"
+        return out_str
 
     def report(self):
-        output.error(f"Unused components: {', '.join(self.unused_components)}")
+        output.error(f"Unused components:")
+        for i, component in enumerate(self.unused_components):
+            output.line(
+                f"    {component}: {' -> '.join(self.breadcrumbs[i])}", red=True
+            )
+        output.tabular("Root", self.root_name, red=True)
 
 
 class UnsatisfiedResources(ConfigurationError):

--- a/src/batou/__init__.py
+++ b/src/batou/__init__.py
@@ -473,6 +473,27 @@ class UnusedResources(ConfigurationError):
             )
 
 
+class UnusedComponentsInitialized(ConfigurationError):
+    """Some components were initialized but never used."""
+
+    sort_key = (5, "unused")
+
+    @classmethod
+    def from_context(cls, components, root):
+        self = cls()
+        self.unused_components = []
+        for component in components:
+            self.unused_components.append(repr(component.__class__.__name__))
+        self.root_name = root.name
+        return self
+
+    def __str__(self):
+        return f"Unused components: {', '.join(self.unused_components)}"
+
+    def report(self):
+        output.error(f"Unused components: {', '.join(self.unused_components)}")
+
+
 class UnsatisfiedResources(ConfigurationError):
     """Some required resources were never provided."""
 

--- a/src/batou/__init__.py
+++ b/src/batou/__init__.py
@@ -494,14 +494,18 @@ class UnusedComponentsInitialized(ConfigurationError):
         return self
 
     def __str__(self):
-        out_str = "Unused components: "
+        out_str = "Some components were initialized but never added to the environment:"
         for i, component in enumerate(self.unused_components):
             out_str += f"\n    {component}: {' -> '.join(self.breadcrumbs[i])}"
             out_str += f"\n        initialized in {self.init_file_paths[i]}:{self.init_line_numbers[i]}"
+        out_str += f"\nRoot: {self.root_name}"
+        out_str += f"\nAdd the components to the environment using `self += component`."
         return out_str
 
     def report(self):
-        output.error(f"Unused components:")
+        output.error(
+            f"Some components were initialized but never added to the environment:"
+        )
         for i, component in enumerate(self.unused_components):
             output.line(
                 f"    {component}: {' -> '.join(self.breadcrumbs[i])}", red=True
@@ -510,6 +514,10 @@ class UnusedComponentsInitialized(ConfigurationError):
                 f"        initialized in {self.init_file_paths[i]}:{self.init_line_numbers[i]}",
                 red=True,
             )
+        output.line(
+            f"Add the components to the environment using `self += component`.",
+            red=True,
+        )
         output.tabular("Root", self.root_name, red=True)
 
 

--- a/src/batou/__init__.py
+++ b/src/batou/__init__.py
@@ -483,9 +483,13 @@ class UnusedComponentsInitialized(ConfigurationError):
         self = cls()
         self.unused_components = []
         self.breadcrumbs = []
+        self.init_file_paths = []
+        self.init_line_numbers = []
         for component in components:
             self.unused_components.append(repr(component.__class__.__name__))
             self.breadcrumbs.append(component._init_breadcrumbs)
+            self.init_file_paths.append(component._init_file_path)
+            self.init_line_numbers.append(component._init_line_number)
         self.root_name = root.name
         return self
 
@@ -493,6 +497,7 @@ class UnusedComponentsInitialized(ConfigurationError):
         out_str = "Unused components: "
         for i, component in enumerate(self.unused_components):
             out_str += f"\n    {component}: {' -> '.join(self.breadcrumbs[i])}"
+            out_str += f"\n        initialized in {self.init_file_paths[i]}:{self.init_line_numbers[i]}"
         return out_str
 
     def report(self):
@@ -500,6 +505,10 @@ class UnusedComponentsInitialized(ConfigurationError):
         for i, component in enumerate(self.unused_components):
             output.line(
                 f"    {component}: {' -> '.join(self.breadcrumbs[i])}", red=True
+            )
+            output.line(
+                f"        initialized in {self.init_file_paths[i]}:{self.init_line_numbers[i]}",
+                red=True,
             )
         output.tabular("Root", self.root_name, red=True)
 

--- a/src/batou/component.py
+++ b/src/batou/component.py
@@ -7,6 +7,7 @@ import os.path
 import sys
 import types
 import weakref
+from typing import List
 
 import batou
 import batou.c
@@ -146,6 +147,13 @@ class Component(object):
     #: working directory to this.
     workdir: str = None
 
+    #: A list of all component instances that have been created. When
+    #: a component is created (__init__) it is added to this list.
+    #: After the configuration phase, this list is checked for
+    #: components that have component._prepared == False and
+    #: warns about them.
+    instances: List["Component"] = []
+
     @property
     def defdir(self):
         """(*readonly*) The definition directory
@@ -188,6 +196,7 @@ class Component(object):
     _prepared = False
 
     def __init__(self, namevar=None, **kw):
+        Component.instances.append(self)
         self.timer = batou.utils.Timer(self.__class__.__name__)
         # Are any keyword arguments undefined attributes?
         # This is a somewhat rough implementation as it allows overriding

--- a/src/batou/component.py
+++ b/src/batou/component.py
@@ -199,6 +199,9 @@ class Component(object):
         init_stack = inspect.stack()
         init_stack.reverse()
         init_breadcrumbs = []
+        call_site = init_stack[-2]
+        self._init_file_path = call_site.filename
+        self._init_line_number = call_site.lineno
         for frame in init_stack:
             if (
                 "self" in frame.frame.f_locals

--- a/src/batou/environment.py
+++ b/src/batou/environment.py
@@ -31,7 +31,7 @@ from batou import (
     UnusedResources,
 )
 from batou._output import output
-from batou.component import ComponentDefinition, RootComponent
+from batou.component import Component, ComponentDefinition, RootComponent
 from batou.provision import Provisioner
 from batou.repository import Repository
 from batou.utils import CycleError, cmd
@@ -565,6 +565,16 @@ class Environment(object):
             exceptions.append(
                 UnusedResources.from_context(self.resources.unused)
             )
+
+        # if any of Component.instances has ._prepared == False, then
+        # warn via output.annotate
+        for component in Component.instances:
+            if not component._prepared:
+                output.annotate(
+                    "Component {} was not prepared.".format(
+                        component.__class__.__name__
+                    ),
+                )
 
         for root in order:
             root.log_finish_configure()

--- a/src/batou/environment.py
+++ b/src/batou/environment.py
@@ -528,10 +528,9 @@ class Environment(object):
                                 unprepared_components, root
                             )
                         )
-                    if not exceptions:
-                        # configured this component successfully
-                        # we won't have to retry it later
-                        continue
+                    # configured this component successfully
+                    # we won't have to retry it later
+                    continue
                 retry.add(root)
 
             retry.update(self.resources.dirty_dependencies)

--- a/src/batou/environment.py
+++ b/src/batou/environment.py
@@ -568,13 +568,14 @@ class Environment(object):
 
         # if any of Component.instances has ._prepared == False, then
         # warn via output.annotate
-        for component in Component.instances:
-            if not component._prepared:
-                output.annotate(
-                    "Component {} was not prepared.".format(
-                        component.__class__.__name__
-                    ),
-                )
+        if not exceptions:
+            for component in Component.instances:
+                if not component._prepared:
+                    output.warn(
+                        "A Component '{}' was initialized but was not prepared (configured).\nThis may not be what you want".format(
+                            component.__class__.__name__
+                        ),
+                    )
 
         for root in order:
             root.log_finish_configure()

--- a/src/batou/environment.py
+++ b/src/batou/environment.py
@@ -523,11 +523,14 @@ class Environment(object):
                         if not component._prepared:
                             unprepared_components.append(component)
                     if unprepared_components:
-                        exceptions.append(
+                        # TODO: activate in future
+                        unused_exception = (
                             UnusedComponentsInitialized.from_context(
                                 unprepared_components, root
                             )
                         )
+                        # exceptions.append(unused_exception)
+                        output.warn(str(unused_exception))
                     # configured this component successfully
                     # we won't have to retry it later
                     continue

--- a/src/batou/remote_core.py
+++ b/src/batou/remote_core.py
@@ -107,6 +107,12 @@ class Output(object):
             out = "      " + out.replace("\n", "\n      ") + "\n"
             self.backend.write(out, red=True)
 
+    def warn(self, message, debug=False):
+        if debug and not self.enable_debug:
+            return
+        self.flush_buffer()
+        self.step("WARN", message, yellow=True)
+
 
 class ChannelBackend(object):
     def __init__(self, channel):

--- a/src/batou/tests/fixture/sample_service/components/hello/component.py
+++ b/src/batou/tests/fixture/sample_service/components/hello/component.py
@@ -62,3 +62,12 @@ class HelloProv(Component):
 class Sub(Component):
     def configure(self):
         self.log("Sub!")
+
+
+class Unused(Component):
+    pass
+
+
+class BadUnused(Component):
+    def configure(self):
+        Unused()

--- a/src/batou/tests/fixture/sample_service/environments/test-unused/environment.cfg
+++ b/src/batou/tests/fixture/sample_service/environments/test-unused/environment.cfg
@@ -1,0 +1,5 @@
+[environment]
+connect_method = local
+
+[hosts]
+localhost = badunused

--- a/src/batou/tests/test_environment.py
+++ b/src/batou/tests/test_environment.py
@@ -334,9 +334,11 @@ def test_resolver_overrides_invalid_address(sample_service):
     assert "thisisinvalid" == errors[0].address
 
 
-def test_unused_components_get_reported(sample_service):
+def test_unused_components_get_reported(sample_service, output):
     e = Environment("test-unused")
     e.load()
-    errors = e.configure()
 
-    assert any(isinstance(e, batou.UnusedComponentsInitialized) for e in errors)
+    output.backend.output = ""
+    e.configure()
+
+    assert "'Unused': BadUnused" in output.backend.output

--- a/src/batou/tests/test_environment.py
+++ b/src/batou/tests/test_environment.py
@@ -4,7 +4,7 @@ from mock import Mock
 
 import batou
 import batou.utils
-from batou.component import Component
+from batou.component import Component, RootComponent
 from batou.environment import Config, Environment
 from batou.host import Host
 
@@ -336,3 +336,11 @@ def test_resolver_overrides_invalid_address(sample_service):
     errors = e.configure()
     assert len(errors) == 1
     assert "thisisinvalid" == errors[0].address
+
+
+def test_unused_components_get_reported(sample_service):
+    e = Environment("test-unused")
+    e.load()
+    errors = e.configure()
+
+    assert any(isinstance(e, batou.UnusedComponentsInitialized) for e in errors)

--- a/src/batou/tests/test_environment.py
+++ b/src/batou/tests/test_environment.py
@@ -287,10 +287,6 @@ def test_components_for_host_can_be_retrieved_from_environment(sample_service):
 
 @mock.patch("batou.remote_core.Output.line")
 def test_log_in_component_configure_is_put_out(output, sample_service):
-    # we are deploying in this test
-    # so we will reset some application state
-    Component.instances = []
-    # this is for tracking which components are used and not
     e = Environment("test-with-provide-require")
     e.load()
     e.configure()

--- a/src/batou/tests/test_environment.py
+++ b/src/batou/tests/test_environment.py
@@ -4,6 +4,7 @@ from mock import Mock
 
 import batou
 import batou.utils
+from batou.component import Component
 from batou.environment import Config, Environment
 from batou.host import Host
 
@@ -286,6 +287,10 @@ def test_components_for_host_can_be_retrieved_from_environment(sample_service):
 
 @mock.patch("batou.remote_core.Output.line")
 def test_log_in_component_configure_is_put_out(output, sample_service):
+    # we are deploying in this test
+    # so we will reset some application state
+    Component.instances = []
+    # this is for tracking which components are used and not
     e = Environment("test-with-provide-require")
     e.load()
     e.configure()


### PR DESCRIPTION
closes #278 

provides a warning if a component is initialized, but not prepared:

Say we have the `tutorial-helloworld`:
`component.py`:
```python
class Hello(Component):
    def configure(self):
        self += File("hello", content="Hello world")
        File("")
```

This gives us an error message like this: 
```
batou/2.5.dev0 (cpython 3.7.16-final0, Darwin 23.1.0 arm64)
================================== Preparing ===================================
main: Loading environment `tutorial`...
main: Verifying repository ...
main: Loading secrets ...
================== Connecting hosts and configuring model ... ==================
localhost: Connecting via local (1/1)
WARN: A Component 'File' was initialized but was not prepared (configured).
This may not be what you want
================================== Deploying ===================================
localhost: Scheduling component hello ...
=================================== Summary ====================================
Deployment took total=0.23s, connect=0.23s, deploy=0.00s
============================= DEPLOYMENT FINISHED ==============================
```

Of course the warning is yellow too:

![image](https://github.com/flyingcircusio/batou/assets/37669174/24c4820f-ee2e-437b-9332-6eda5a5a46ec)
