### PR TITLE
Add traceback to component loading error

### DIFF
--- a/src/batou/__init__.py
+++ b/src/batou/__init__.py
@@ -22,7 +22,7 @@ def prepare_traceback(tb):
     from batou import component, environment
 
     stack = traceback.extract_tb(tb)
-    while True:
+    while stack:
         # Delete remoting-internal stack frames.'
         line = stack.pop(0)
         if line[0] in [
@@ -34,6 +34,8 @@ def prepare_traceback(tb):
             continue
         stack.insert(0, line)
         break
+    if not stack:
+        return "<no-non-remote-internal-traceback-lines-found>"
     return "".join(traceback.format_list(stack))
 
 

--- a/src/batou/environment.py
+++ b/src/batou/environment.py
@@ -215,8 +215,9 @@ class Environment(object):
             try:
                 self.components.update(load_components_from_file(filename))
             except Exception as e:
+                exc_type, ex, tb = sys.exc_info()
                 self.exceptions.append(
-                    ComponentLoadingError.from_context(filename, e)
+                    ComponentLoadingError.from_context(filename, e, tb)
                 )
 
         config = Config(config_file)

--- a/src/batou/tests/test_deploy.py
+++ b/src/batou/tests/test_deploy.py
@@ -37,10 +37,16 @@ main: Loading secrets ...
 ERROR: Failed loading component file
            File: .../examples/errors/components/component5/component.py
       Exception: invalid syntax (component.py, line 1)
+Traceback (simplified, most recent call last):
+<no-non-remote-internal-traceback-lines-found>
 
 ERROR: Failed loading component file
            File: .../examples/errors/components/component6/component.py
       Exception: No module named 'asdf'
+Traceback (simplified, most recent call last):
+  File ".../examples/errors/components/component6/component.py", line 1, in <module>
+    import asdf  # noqa: F401 import unused
+
 
 ERROR: Missing component
       Component: missingcomponent

--- a/src/batou/tests/test_endtoend.py
+++ b/src/batou/tests/test_endtoend.py
@@ -31,10 +31,16 @@ main: Loading secrets ...
 ERROR: Failed loading component file
            File: .../examples/errors/components/component5/component.py
       Exception: invalid syntax (component.py, line 1)
+Traceback (simplified, most recent call last):
+<no-non-remote-internal-traceback-lines-found>
 
 ERROR: Failed loading component file
            File: .../examples/errors/components/component6/component.py
       Exception: No module named 'asdf'
+Traceback (simplified, most recent call last):
+  File ".../errors/components/component6/component.py", line 1, in <module>
+    import asdf  # noqa: F401 import unused
+
 
 ERROR: Missing component
       Component: missingcomponent
@@ -77,10 +83,16 @@ gpg: ...
 ERROR: Failed loading component file
            File: .../examples/errors/components/component5/component.py
       Exception: invalid syntax (component.py, line 1)
+Traceback (simplified, most recent call last):
+<no-non-remote-internal-traceback-lines-found>
 
 ERROR: Failed loading component file
            File: .../examples/errors/components/component6/component.py
       Exception: No module named 'asdf'
+Traceback (simplified, most recent call last):
+  File ".../examples/errors/components/component6/component.py", line 1, in <module>
+    import asdf  # noqa: F401 import unused
+
 
 ERROR: Missing component
       Component: missingcomponent

--- a/src/batou/tests/test_exceptions.py
+++ b/src/batou/tests/test_exceptions.py
@@ -61,7 +61,7 @@ def test_configurationerrors_can_be_sorted(root):
     errors.append(MissingEnvironment.from_context(root.environment))
 
     errors.append(
-        ComponentLoadingError.from_context("asdf.py", ValueError("asdf"))
+        ComponentLoadingError.from_context("asdf.py", ValueError("asdf"), None)
     )
 
     errors.append(MissingComponent.from_context("component", "hostname"))


### PR DESCRIPTION
Closes #261 

Looks like this:

```
% ./batou deploy tutorial
batou/2.5.dev0 (cpython 3.7.16-final0, Darwin 23.1.0 arm64)
=================================================== Preparing ====================================================
main: Loading environment `tutorial`...
main: Verifying repository ...
main: Loading secrets ...

ERROR: Failed loading component file
           File: /Users/elikoga/batou/examples/tutorial-helloworld/components/hello/component.py
      Exception: __init__() takes from 1 to 5 positional arguments but 6 were given
Traceback (simplified, most recent call last):
  File "/Users/elikoga/batou/examples/tutorial-helloworld/components/hello/component.py", line 5, in <module>
    class Hello(Component):
  File "/Users/elikoga/batou/examples/tutorial-helloworld/components/hello/component.py", line 6, in Hello
    asd = Attribute(1, 2, 3, 4, 5)


ERROR: Missing component
      Component: hello
======================================== DEPLOYMENT FAILED (during load) =========================================
```

