### PR TITLE
Make ensure_path_nonexistent race condition aware

### DIFF
--- a/src/batou/lib/file.py
+++ b/src/batou/lib/file.py
@@ -24,7 +24,7 @@ def ensure_path_nonexistent(path: str) -> None:
     strategy: create a temporary directory, move the path into it
     and delete the temporary directory.
     """
-    if not os.path.exists(path):
+    if not os.path.lexists(path):
         return
 
     parent_dir = os.path.dirname(os.path.abspath(path))
@@ -38,6 +38,7 @@ def ensure_path_nonexistent(path: str) -> None:
 
 
 class File(Component):
+
     namevar = "path"
 
     ensure = "file"  # or: directory, symlink
@@ -150,11 +151,13 @@ class File(Component):
 
 
 class BinaryFile(File):
+
     is_template = False
     encoding = None
 
 
 class Presence(Component):
+
     namevar = "path"
     leading = False
 
@@ -188,6 +191,7 @@ class Presence(Component):
 
 
 class SyncDirectory(Component):
+
     namevar = "path"
     source = None
     exclude = ()
@@ -242,6 +246,7 @@ class SyncDirectory(Component):
 
 
 class Directory(Component):
+
     namevar = "path"
     leading = False
     source = None
@@ -294,6 +299,7 @@ class Directory(Component):
 
 
 class FileComponent(Component):
+
     namevar = "path"
     leading = False
 
@@ -536,6 +542,7 @@ class Content(ManagedContentBase):
 
 
 class JSONContent(ManagedContentBase):
+
     # Data to be used.
     data = None
 
@@ -570,6 +577,7 @@ class JSONContent(ManagedContentBase):
 
 
 class YAMLContent(ManagedContentBase):
+
     # Data to be used.
     data = None
 
@@ -588,6 +596,7 @@ class YAMLContent(ManagedContentBase):
 
 
 class Owner(FileComponent):
+
     owner = None
 
     def verify(self):
@@ -602,6 +611,7 @@ class Owner(FileComponent):
 
 
 class Group(FileComponent):
+
     group = None
 
     def verify(self):
@@ -646,6 +656,7 @@ def convert_mode(string: str) -> int:
 
 
 class Mode(FileComponent):
+
     mode = Attribute(default=None)
 
     def configure(self):
@@ -692,6 +703,7 @@ class Mode(FileComponent):
 
 
 class Symlink(Component):
+
     namevar = "target"
     source = None
 

--- a/src/batou/lib/file.py
+++ b/src/batou/lib/file.py
@@ -17,13 +17,28 @@ from batou import output
 from batou.component import Attribute, Component
 from batou.utils import dict_merge
 
+# Explain the logic that in a multi-user and concurrent system there isn't really a coarse grained guarantee around files not existing.
+
+# What this can guarantee, however, is that during the lifetime of this function call, there will have been an atomic moment where the file did not exist, or, if it existed and can not be removed, it will raise an error.
+
+# This means: if the file wasn't there in the first place, we're fine. If the file existed and we removed it, we are fine, we don't care whether someone else might have recreated it immediately after. If the file existed and was removed by someone else, we don't care either. If the file existed and we can't remove it, we need to fail.
+
 
 def ensure_path_nonexistent(path: str) -> None:
     """Ensure that the given path does not exist.
 
-    strategy: create a temporary directory, move the path into it
-    and delete the temporary directory.
+    In a multi-user/concurrent environment, it is possible that a path is created
+    at any time. This function will ensure that the path does not exist at some
+    point in time during the execution of this function.
+
+    During the lifetime of this function call, there will have been an atomic
+    moment where the file did not exist, or, if it existed and can not be
+    removed, it will raise an error.
+
+    This function will not guarantee that the path does not exist after this
+    function has returned.
     """
+
     if not os.path.lexists(path):
         return
 
@@ -31,10 +46,11 @@ def ensure_path_nonexistent(path: str) -> None:
     path_basename = os.path.basename(os.path.normpath(path))
 
     with tempfile.TemporaryDirectory(dir=parent_dir) as temp_dir:
-        os.rename(path, os.path.join(temp_dir, path_basename))
-        # deletes temp_dir on context manager exit
-
-    assert not os.path.exists(path), f"{path} still exists after rename, race?"
+        try:
+            os.rename(path, os.path.join(temp_dir, path_basename))
+        except FileNotFoundError as e:
+            # The file was not there in the first place, we're done.
+            pass
 
 
 class File(Component):

--- a/src/batou/lib/file.py
+++ b/src/batou/lib/file.py
@@ -5,6 +5,7 @@ import itertools
 import json
 import os.path
 import pwd
+import random
 import re
 import shutil
 import stat
@@ -44,7 +45,6 @@ def ensure_path_nonexistent(path):
 
 
 class File(Component):
-
     namevar = "path"
 
     ensure = "file"  # or: directory, symlink
@@ -157,13 +157,11 @@ class File(Component):
 
 
 class BinaryFile(File):
-
     is_template = False
     encoding = None
 
 
 class Presence(Component):
-
     namevar = "path"
     leading = False
 
@@ -197,7 +195,6 @@ class Presence(Component):
 
 
 class SyncDirectory(Component):
-
     namevar = "path"
     source = None
     exclude = ()
@@ -252,7 +249,6 @@ class SyncDirectory(Component):
 
 
 class Directory(Component):
-
     namevar = "path"
     leading = False
     source = None
@@ -305,7 +301,6 @@ class Directory(Component):
 
 
 class FileComponent(Component):
-
     namevar = "path"
     leading = False
 
@@ -548,7 +543,6 @@ class Content(ManagedContentBase):
 
 
 class JSONContent(ManagedContentBase):
-
     # Data to be used.
     data = None
 
@@ -583,7 +577,6 @@ class JSONContent(ManagedContentBase):
 
 
 class YAMLContent(ManagedContentBase):
-
     # Data to be used.
     data = None
 
@@ -602,7 +595,6 @@ class YAMLContent(ManagedContentBase):
 
 
 class Owner(FileComponent):
-
     owner = None
 
     def verify(self):
@@ -617,7 +609,6 @@ class Owner(FileComponent):
 
 
 class Group(FileComponent):
-
     group = None
 
     def verify(self):
@@ -662,7 +653,6 @@ def convert_mode(string: str) -> int:
 
 
 class Mode(FileComponent):
-
     mode = Attribute(default=None)
 
     def configure(self):
@@ -709,7 +699,6 @@ class Mode(FileComponent):
 
 
 class Symlink(Component):
-
     namevar = "target"
     source = None
 

--- a/src/batou/lib/tests/test_file.py
+++ b/src/batou/lib/tests/test_file.py
@@ -74,15 +74,6 @@ def test_ensure_path_does_not_fail_on_nonexisting_path():
     assert not os.path.exists("missing")
 
 
-def test_ensure_path_nonexistent_fails_if_os_rename_is_dummied(tmpdir):
-    os.chdir(str(tmpdir))
-    os.mkdir("dir")
-    with patch("os.rename", Mock(return_value=None)):
-        with pytest.raises(AssertionError) as e:
-            ensure_path_nonexistent("dir")
-    assert "race" in str(e.value)
-
-
 def test_presence_creates_nonexisting_file(root):
     p = Presence("path")
     root.component += p

--- a/src/batou/lib/tests/test_file.py
+++ b/src/batou/lib/tests/test_file.py
@@ -80,7 +80,7 @@ def test_ensure_path_nonexistent_fails_if_os_rename_is_dummied(tmpdir):
     with patch("os.rename", Mock(return_value=None)):
         with pytest.raises(AssertionError) as e:
             ensure_path_nonexistent("dir")
-    assert "race condition" in str(e.value)
+    assert "race" in str(e.value)
 
 
 def test_presence_creates_nonexisting_file(root):

--- a/src/batou/lib/tests/test_file.py
+++ b/src/batou/lib/tests/test_file.py
@@ -74,6 +74,15 @@ def test_ensure_path_does_not_fail_on_nonexisting_path():
     assert not os.path.exists("missing")
 
 
+def test_ensure_path_nonexistent_fails_if_os_rename_is_dummied(tmpdir):
+    os.chdir(str(tmpdir))
+    os.mkdir("dir")
+    with patch("os.rename", Mock(return_value=None)):
+        with pytest.raises(AssertionError) as e:
+            ensure_path_nonexistent("dir")
+    assert "race condition" in str(e.value)
+
+
 def test_presence_creates_nonexisting_file(root):
     p = Presence("path")
     root.component += p


### PR DESCRIPTION
This is susceptible to the same race conditions as the implementation from before, however it is able to notice the race condition and fail accordingly.

closes #275 