### PR TITLE
bump sphinx for readthedocs builder compatibility

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,5 +15,5 @@ six==1.15.0
 toml==0.10.2
 tox==3.20.1
 virtualenv==20.1.0
-sphinx==4.0.2
+sphinx==4.2.0
 recommonmark==0.7.1


### PR DESCRIPTION
Since https://github.com/sphinx-doc/sphinx/issues/9562 makes our readthedocs build fail