### PR TITLE
docs: correct prefix for plain age pubkeys

### DIFF
--- a/doc/source/user/age.md
+++ b/doc/source/user/age.md
@@ -29,7 +29,7 @@ You can see that using the `age` secret provider allows us to specify keys from
 https sources. This is because age accepts ssh public keys as encryption recipients.
 
 We accept ssh public keys (beginning with `ssh-`) as well as age public keys
-(beginning with `age1-`), or `http(s)://` urls to ssh public-key files.
+(beginning with `age1`), or `http(s)://` urls to ssh public-key files.
 
 GPG is still supported as before.
 


### PR DESCRIPTION
There's no dash, these start with `age1` only:

    → age-keygen >/dev/null
    Public key: age1r046cnu3486qvrkds3xg3gztrzcmzustg770ls3hgvgt2jc2ffkq3wrsmf

Just checked in one of our projects and batou 2.4.2 happily accepts those keys as well, so the only thing to do is fixing the docs.