### PR TITLE
Change Environment.filter logic

### DIFF
--- a/src/batou/environment.py
+++ b/src/batou/environment.py
@@ -162,10 +162,9 @@ class Environment(object):
 
     @classmethod
     def filter(cls, filter):
-        if filter:
-            filter = filter.split(",")
-        else:
+        if not filter:
             return list(cls.all())
+        filter = filter.split(",")
         environments = []
         for e in cls.all():
             if e.name not in filter:

--- a/src/batou/environment.py
+++ b/src/batou/environment.py
@@ -162,7 +162,6 @@ class Environment(object):
 
     @classmethod
     def filter(cls, filter):
-        filter_is_age = filter == "age"
         if filter:
             filter = filter.split(",")
         environments = []
@@ -172,14 +171,9 @@ class Environment(object):
                     filter.remove(e.name)
                 else:
                     continue
-            environments.append(e)
+                environments.append(e)
         if filter:
             raise UnknownEnvironmentError(filter)
-        print(f"DEBUG: Environment.filter({filter}) -> {environments}")
-        if filter_is_age:
-            assert (
-                len(environments) == 1
-            ), "DEBUG: filter_is_age, but len(environments) != 1"
         return environments
 
     def _environment_path(self, path="."):

--- a/src/batou/environment.py
+++ b/src/batou/environment.py
@@ -162,6 +162,7 @@ class Environment(object):
 
     @classmethod
     def filter(cls, filter):
+        filter_is_age = filter == "age"
         if filter:
             filter = filter.split(",")
         environments = []
@@ -175,6 +176,10 @@ class Environment(object):
         if filter:
             raise UnknownEnvironmentError(filter)
         print(f"DEBUG: Environment.filter({filter}) -> {environments}")
+        if filter_is_age:
+            assert (
+                len(environments) == 1
+            ), "DEBUG: filter_is_age, but len(environments) != 1"
         return environments
 
     def _environment_path(self, path="."):

--- a/src/batou/environment.py
+++ b/src/batou/environment.py
@@ -174,6 +174,7 @@ class Environment(object):
             environments.append(e)
         if filter:
             raise UnknownEnvironmentError(filter)
+        print(f"DEBUG: Environment.filter({filter}) -> {environments}")
         return environments
 
     def _environment_path(self, path="."):

--- a/src/batou/environment.py
+++ b/src/batou/environment.py
@@ -164,6 +164,8 @@ class Environment(object):
     def filter(cls, filter):
         if filter:
             filter = filter.split(",")
+        else:
+            return list(cls.all())
         environments = []
         for e in cls.all():
             if filter:

--- a/src/batou/environment.py
+++ b/src/batou/environment.py
@@ -168,12 +168,10 @@ class Environment(object):
             return list(cls.all())
         environments = []
         for e in cls.all():
-            if filter:
-                if e.name in filter:
-                    filter.remove(e.name)
-                else:
-                    continue
-                environments.append(e)
+            if e.name not in filter:
+                continue
+            filter.remove(e.name)
+            environments.append(e)
         if filter:
             raise UnknownEnvironmentError(filter)
         return environments


### PR DESCRIPTION
Previously, if the filter ran out of filter elements but there are still environments left, they get silently added. Apparently, due to file system ordering this was previously masked in all tests

Unless this was intended previously?

https://github.com/flyingcircusio/batou/commit/37c542fddc4175770f785d3191a606be51279668#diff-b59e4ac305b8d689da39dd33337351920c23860934a20f8f10e13352734f78d0R53-R63

This was used to provide the semantic: "If no filter is provided, all environments are meant". Now it's an explicit path