### PR TITLE
GitBundleRepository._ship: fix behaviour after history rewriting

### DIFF
--- a/CHANGES.d/20241029_102331_elikowa_git_bundle_do_not_fail_after_rebase.md
+++ b/CHANGES.d/20241029_102331_elikowa_git_bundle_do_not_fail_after_rebase.md
@@ -1,0 +1,5 @@
+- When shipping a repository to the remote host using `git-bundle`, previously, when
+  the history of the repository was rewritten, the bundle would fail to be created, due
+  to the remote `HEAD` not being a predecessor of the local `HEAD`. This has been fixed
+  by creating the bundle using the whole branch history, instead of just the changes between
+  remote `HEAD` and branch `HEAD` when the remote `HEAD` is not a part of the branch.

--- a/src/batou/tests/test_remote.py
+++ b/src/batou/tests/test_remote.py
@@ -38,30 +38,6 @@ def test_remote_bundle_breaks_on_missing_head(sample_service):
     )
 
 
-def test_git_remote_bundle_fails_if_needed(tmp_path):
-    env = mock.Mock()
-    env.base_dir = tmp_path
-    env.branch = "master"
-    host = mock.Mock()
-    host.rpc.git_current_head.return_value.decode.return_value = "HEAD"
-    from batou.repository import GitBundleRepository
-
-    os.chdir(tmp_path)
-    cmd("git init")
-    cmd("touch foo")
-    cmd("git add foo")
-    cmd("git commit -m 'initial commit'")
-    repository = GitBundleRepository(env)
-    assert repository._ship(host) is None
-
-    # now destroy the repository state
-    head_commit = cmd("git rev-parse HEAD")[0].strip()
-    cmd(f"rm -rf .git/objects/{head_commit[:2]}/{head_commit[2:]}")
-    with pytest.raises(CmdExecutionError) as e:
-        repository._ship(host)
-    assert "Invalid revision range" in str(e.value)
-
-
 def test_remotehost_start(sample_service):
     env = Environment("test-with-env-config")
     env.load()


### PR DESCRIPTION
bundle everything and ignore remote head if current head is not in local branch

Tried writing a `test_git_remote_bundle_can_handle_removed_head_commit` similiar to `test_git_remote_init_pull` but due to deficiencies in the remote test suite this presented too difficult.

This change cleanly appllies the local state to the remote repository in case of a rewrite. Due to `host.rpc.git_update_working_copy` running `git reset --hard` https://github.com/flyingcircusio/batou/blob/1e0d7a239992c715c2419f9129ac50c1641487b8/src/batou/repository.py#L318-L326 https://github.com/flyingcircusio/batou/blob/1e0d7a239992c715c2419f9129ac50c1641487b8/src/batou/remote_core.py#L348-L355