### PR TITLE
Improve deployment performance when there are many components.

### DIFF
--- a/CHANGES.d/20241118_094425_cz_improve_component_init_performance.md
+++ b/CHANGES.d/20241118_094425_cz_improve_component_init_performance.md
@@ -1,0 +1,3 @@
+- Improve deployment performance when there are many components.
+
+  Improves the performance of `Component.__init__` which is called very often.


### PR DESCRIPTION
Improves the performance of `Component.__init__` which is called very often.

@elikoga I'm not sure if this is tested enough. No tests break, so I would *assume* the functionality is the same, but please have a look.