### PR TITLE
Improve usability in git workflows

### DIFF
--- a/CHANGES.d/20250224_121544_ph_HEAD.md
+++ b/CHANGES.d/20250224_121544_ph_HEAD.md
@@ -1,0 +1,2 @@
+- improve usability of `batou secrets decrypttostdout` as a git filter
+- the ssh key passphrase can now be provided directly via `BATOU_AGE_IDENTITY_PASSPHRASE`

--- a/src/batou/secrets/encryption.py
+++ b/src/batou/secrets/encryption.py
@@ -279,11 +279,7 @@ def get_passphrase(identity: str) -> str:
     op = os.environ.get("BATOU_AGE_IDENTITY_PASSPHRASE")
 
     if op and not op.startswith("op://"):
-        raise ValueError(
-            "The environment variable BATOU_AGE_IDENTITY_PASSPHRASE is set, "
-            "but it's not an 1password url"
-        )
-
+        passphrase = op
     if op:
         op_process = subprocess.run(
             ["op", "read", op],

--- a/src/batou/secrets/manage.py
+++ b/src/batou/secrets/manage.py
@@ -91,6 +91,9 @@ def decrypt_to_stdout(file: str):
     file_path = pathlib.Path(file).absolute()
     with get_encrypted_file(file_path) as encrypted_file:
         decrypted = encrypted_file.decrypt()
-    sys.stdout.buffer.write(decrypted)
+    if decrypted:
+        sys.stdout.buffer.write(decrypted)
+    else:
+        print("(unable to decrypt content)")
     sys.stdout.flush()
     return 0


### PR DESCRIPTION
This change introduces two changes to improve using batou as a git diff filter via `batou secrets decrypttostdout`:

1. Enable providing the ssh key's passphrase directly without having to launch a new subprocess to get it from `op` (300+ ms each) for every single operation. Git filters are run a lot so the subprocess call alone introduces a lot of extra overhead. Example uses of this would be running `op run -- git diff ...` or injecting the passphrase into an environment variable using `direnv` in combination with `op`.

2. Gracefully handle cases where the provided ssh key is not a recipient for the requested secret. In those cases the `decrypt()` method will return `None`, causing the call to `sys.stdout.write` to panic. Due to the way git filters are handled, a non-zero return code will abort the entire operation, which is why a human-readable error in the output has to suffice here.