### PR TITLE
Fix git bundle shipping: Due to a bug, the entire branch was shipped …

### DIFF
--- a/CHANGES.d/20250305_084857_cz_fix_git_bundle_shipping.md
+++ b/CHANGES.d/20250305_084857_cz_fix_git_bundle_shipping.md
@@ -1,0 +1,1 @@
+- Fix git bundle shipping: Due to a bug, the entire branch was shipped on every deployment. This also required a lot of memory (#490)

--- a/src/batou/repository.py
+++ b/src/batou/repository.py
@@ -385,7 +385,7 @@ class GitPullRepository(GitRepository):
 
 class GitBundleRepository(GitRepository):
     def _ship(self, host):
-        head = host.rpc.git_current_head()
+        head = host.rpc.git_current_head().decode("ascii")
         if head:
             # check if head is in local branch, if not, bundle everything and ignore remote head
             try:
@@ -398,7 +398,6 @@ class GitBundleRepository(GitRepository):
         if head is None:
             bundle_range = self.branch
         else:
-            head = head.decode("ascii")
             bundle_range = f"{head}..{self.branch}"
         fd, bundle_file = tempfile.mkstemp()
         os.close(fd)


### PR DESCRIPTION
…on every deployment. This also required a lot of memory (#490)