### PR TITLE
Limit terminal column width in tox tests for all user environments

### DIFF
--- a/src/batou/_output.py
+++ b/src/batou/_output.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from batou.remote_core import Output
@@ -8,6 +9,9 @@ class TerminalBackend(object):
         import py.io
 
         self._tw = py.io.TerminalWriter(sys.stdout)
+
+        if os.environ.get("IN_TOX_TEST") == "1":
+            self._tw.fullwidth = 80
 
     def line(self, message, **format):
         self._tw.line(message, **format)

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ usedevelop = true
 setenv =
     APPENV_BEST_PYTHON = {envpython}
     COLUMNS = 80
+    IN_TOX_TEST = 1
 extras = test
 commands = pytest {posargs}
 


### PR DESCRIPTION
Limit the terminal column width in test when called with tox to ensure reproducible end to end output logs in all environments