### PR TITLE
Rolls back a #493 behaviour change with respect to link handling when provisioning+Escape macos notify calls

### DIFF
--- a/src/batou/provision.py
+++ b/src/batou/provision.py
@@ -60,7 +60,7 @@ RUN() {{
 COPY() {{
     what=${{1?what to copy}}
     where=${{2?where to copy}}
-    rsync -avz --no-owner --no-group --safe-links {rsync_path} $what $PROVISION_VM:$where
+    rsync -avz --no-owner --no-group --no-links --safe-links {rsync_path} $what $PROVISION_VM:$where
 }}
 
 if [ ${{PROVISION_REBUILD+x}} ]; then

--- a/src/batou/tests/test_utils.py
+++ b/src/batou/tests/test_utils.py
@@ -21,6 +21,7 @@ from batou.utils import (
     hash,
     locked,
     notify,
+    notify_macosx,
     remove_nodes_without_outgoing_edges,
     resolve,
     resolve_v6,
@@ -353,6 +354,23 @@ class NotifyTests(unittest.TestCase):
     @mock.patch("subprocess.check_call", side_effect=OSError)
     def test_notify_does_not_fail_if_os_call_fails(self, call):
         notify("foo", "bar")
+
+    @mock.patch("subprocess.call")
+    def test_macos_notify_gets_escaped(self, event_mocked):
+        notify_text = (
+            "This is a test with a 'single quote' and a \"double quote\"."
+        )
+        notify_macosx(notify_text, notify_text)
+        self.assertEqual(
+            event_mocked.call_args.args,
+            (
+                [
+                    "osascript",
+                    "-e",
+                    'display notification "This is a test with a \'single quote\' and a \\"double quote\\"." with title "This is a test with a \'single quote\' and a \\"double quote\\"."',
+                ],
+            ),
+        )
 
 
 def test_revert_graph_no_edges_is_identical():

--- a/src/batou/utils.py
+++ b/src/batou/utils.py
@@ -101,13 +101,19 @@ def notify_send(title, description):
     subprocess.call(["notify-send", title, description])
 
 
+def escape_macosx_string(s):
+    """Escape a string for use in an osascript command."""
+    return s.replace('"', '\\"')
+
+
 def notify_macosx(title, description):
     subprocess.call(
         [
             "osascript",
             "-e",
             'display notification "{}" with title "{}"'.format(
-                description, title
+                escape_macosx_string(description),
+                escape_macosx_string(title),
             ),
         ]
     )


### PR DESCRIPTION
Related to changes introduced in #493