### PR TITLE
Only try to create mysql db if it doesn't exist.

### DIFF
--- a/CHANGES.d/20260609_124320_cz_mysql_improv.md
+++ b/CHANGES.d/20260609_124320_cz_mysql_improv.md
@@ -1,0 +1,3 @@
+- Only try to create mysql db if it doesn't exist.
+
+  This helps with long running mysql connections which stall a noop create, too.

--- a/src/batou/lib/mysql.py
+++ b/src/batou/lib/mysql.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from textwrap import dedent
 
 from batou import UpdateNeeded
 from batou.component import Component
@@ -78,13 +79,23 @@ class Database(Component):
 
     def configure(self):
         create_db = self.expand(
-            """\
-CREATE DATABASE IF NOT EXISTS
-    {{component.database}}
-    DEFAULT CHARACTER SET = '{{component.charset}}';
-"""
+            dedent("""\
+                    CREATE DATABASE IF NOT EXISTS
+                        {{component.database}}
+                        DEFAULT CHARACTER SET = '{{component.charset}}';
+                    """)
         )
-        self += Command(create_db, admin_password=self.admin_password)
+        unless = self.expand(
+            dedent("""\
+                    SELECT SCHEMA_NAME FROM information_schema.SCHEMATA
+                    WHERE SCHEMA_NAME = '{{component.database}}';
+                    """)
+        )
+        self += Command(
+            create_db,
+            unless=unless,
+            admin_password=self.admin_password,
+        )
 
         if self.base_import_file:
             self += Command(


### PR DESCRIPTION
This helps with long running mysql connections which stall a noop create, too.