### PR TITLE
Make the rsync binaries used by rsync-ext configurable

### DIFF
--- a/CHANGES.d/20260601_091701_mm_configurable_rsync_path.md
+++ b/CHANGES.d/20260601_091701_mm_configurable_rsync_path.md
@@ -1,0 +1,1 @@
+- Add `rsync_path` and `remote_rsync_path` environment options and `rsync_path` host option to allow configuring the path to the local and remote rsync binaries when using the `rsync-ext` repository type.

--- a/doc/source/api/environment.txt
+++ b/doc/source/api/environment.txt
@@ -56,6 +56,20 @@ require_sudo
     always be used unconditionally. If set to `False` then `sudo` will
     never be used.
 
+rsync_path
+
+    Set the name of the external rsync binary executed on the operator's
+    machine when performing a deployment when using the `rsync-ext` update
+    method. If unspecified, batou will use the rsync program in the operator's
+    PATH.
+
+remote_rsync_path
+    Set the name of the external rsync binary executed on target machines when
+    perform a deployment using the `rsync-ext` update method. If unspecified,
+    batou wil use the rsync program in the target machine's PATH. This option
+    can be overridden on a per-host basis using the `rsync_path` host
+    configuration option.
+
 vfs mapping (TODO)
 ------------------
 

--- a/src/batou/environment.py
+++ b/src/batou/environment.py
@@ -118,6 +118,9 @@ class Environment(object):
     repository_url = None
     repository_root = None
 
+    rsync_path = None
+    remote_rsync_path = None
+
     provision_rebuild = False
 
     host_factory = Host
@@ -280,6 +283,8 @@ class Environment(object):
             "timeout",
             "repository_url",
             "repository_root",
+            "rsync_path",
+            "remote_rsync_path",
             "jobs",
         ]:
             if key not in environment:

--- a/src/batou/host.py
+++ b/src/batou/host.py
@@ -116,6 +116,7 @@ _no_value_marker = object()
 class Host(object):
     service_user = None
     require_sudo = None
+    rsync_path = None
     ignore = False
     platform = None
     _provisioner = None
@@ -144,6 +145,10 @@ class Host(object):
             self.require_sudo = ast.literal_eval(config.get("require_sudo"))
         else:
             self.require_sudo = environment.require_sudo
+
+        self.rsync_path = config.get(
+            "rsync_path", environment.remote_rsync_path
+        )
 
         self.remap = ast.literal_eval(
             config.get("provision-dynamic-hostname", "False")

--- a/src/batou/repository.py
+++ b/src/batou/repository.py
@@ -137,6 +137,12 @@ class RSyncExtRepository(Repository):
     def update(self, host):
         source, dest = self.root, host.remote_repository
 
+        local_rsync = remote_rsync = "rsync"
+        if self.environment.rsync_path:
+            local_rsync = self.environment.rsync_path
+        if host.rsync_path:
+            remote_rsync = host.rsync_path
+
         rsync_args = self.SYNC_OPTS.copy()
 
         ssh_configs = [
@@ -153,13 +159,18 @@ class RSyncExtRepository(Repository):
 
         if host.require_sudo:
             rsync_args.append(
-                "--rsync-path='sudo -ni -u {} rsync'".format(host.service_user)
+                "--rsync-path='sudo -ni -u {} {}'".format(
+                    host.service_user, remote_rsync
+                )
             )
+        else:
+            rsync_args.append("--rsync-path='{}'".format(remote_rsync))
 
         output.annotate("rsync-ext: {} -> {}".format(source, dest), debug=True)
 
         cmd(
-            "rsync {opts} {source}/ {target}:{dest}".format(
+            "{rsync} {opts} {source}/ {target}:{dest}".format(
+                rsync=local_rsync,
                 opts=" ".join(rsync_args),
                 source=source,
                 target=host.fqdn,


### PR DESCRIPTION
This change adds configuration options to allow the path to the rsync binaries on the operator's machine and the remote machines to be configured when using the `rsync-ext` repository type, instead of relying on `rsync` being present in the PATH both locally and remotely.

There are a couple of different rsync implementations floating around these days, which aren't necessarily installed under the "rsync" name or in the PATH.