### PR TITLE
Allow manually overriding host ignores at runtime from the CLI

### DIFF
--- a/CHANGES.d/20260819_144211_mm_deploy_cli_ignore.md
+++ b/CHANGES.d/20260819_144211_mm_deploy_cli_ignore.md
@@ -1,0 +1,1 @@
+- Add a new `-I` option to `batou deploy` to allow ignoring hosts when deploying without modifying the environment configuration.

--- a/doc/source/cli/index.txt
+++ b/doc/source/cli/index.txt
@@ -30,9 +30,8 @@ batou deploy
 
 .. code-block:: console
 
-  usage: batou deploy [-h] [-p PLATFORM] [-t TIMEOUT] [-D] [-c] [-P]
-                      [--local] [-j JOBS]
-                      [--provision-rebuild]
+  usage: batou deploy [-h] [-p PLATFORM] [-t TIMEOUT] [-D] [-c] [-P] [-L] [-j JOBS]
+                      [-I IGNORE_HOSTS] [--provision-rebuild]
                       environment
 
   positional arguments:
@@ -59,6 +58,10 @@ batou deploy
                           default results in a serial deployment of components.
                           Will override the environment settings for operational
                           flexibility.
+    -I IGNORE_HOSTS, --ignore IGNORE_HOSTS
+                          Comma-separated list of hosts to ignore. Equivalent to
+                          the host setting ignore=True in the environment
+                          configuration file.
     --provision-rebuild   Rebuild provisioned resources from scratch. DANGER:
                           this is potentially destructive.
 

--- a/src/batou/deploy.py
+++ b/src/batou/deploy.py
@@ -111,6 +111,7 @@ class Deployment(object):
         timeout,
         dirty,
         jobs,
+        ignore_hosts=set(),
         consistency_only=False,
         predict_only=False,
         check_and_predict_local=False,
@@ -120,6 +121,7 @@ class Deployment(object):
             environment,
             timeout,
             platform,
+            ignore_hosts=ignore_hosts,
             provision_rebuild=provision_rebuild,
             check_and_predict_local=check_and_predict_local,
         )
@@ -385,6 +387,7 @@ def main(
     predict_only,
     check_and_predict_local,
     jobs,
+    ignore_hosts,
     provision_rebuild,
 ):
     output.backend = TerminalBackend()
@@ -415,6 +418,7 @@ def main(
             timeout,
             dirty,
             jobs,
+            ignore_hosts,
             consistency_only,
             predict_only,
             check_and_predict_local,

--- a/src/batou/environment.py
+++ b/src/batou/environment.py
@@ -23,6 +23,7 @@ from batou import (
     MissingComponent,
     MissingEnvironment,
     NonConvergingWorkingSet,
+    ReportingException,
     SilentConfigurationError,
     SuperfluousComponentSection,
     SuperfluousSection,
@@ -51,6 +52,24 @@ class UnknownEnvironmentError(ValueError):
 
     def __str__(self):
         return f"Unknown environment(s): {', '.join(self.names)}"
+
+
+class NonExistentIgnoredHostError(ReportingException):
+    """The manually ignored hosts do not exist in the environment."""
+
+    @classmethod
+    def from_context(cls, ignored: list):
+        self = cls()
+        self.ignored = ignored
+        return self
+
+    def __str__(self):
+        return f"Nonexistent manually ignored hosts: {', '.join(self.ignored)}"
+
+    def report(self):
+        output.error(
+            f"Nonexistent manually ignored hosts: {', '.join(self.ignored)}"
+        )
 
 
 class ConfigSection(dict):
@@ -122,12 +141,15 @@ class Environment(object):
 
     host_factory = Host
 
+    ignore_hosts = set()
+
     def __init__(
         self,
         name,
         timeout=None,
         platform=None,
         basedir=".",
+        ignore_hosts=set(),
         provision_rebuild=False,
         check_and_predict_local=False,
     ):
@@ -139,6 +161,7 @@ class Environment(object):
         self.exceptions: List[Exception] = []
         self.timeout = timeout
         self.platform = platform
+        self.ignore_hosts = ignore_hosts
         self.provision_rebuild = provision_rebuild
         self.check_and_predict_local = check_and_predict_local
 
@@ -358,6 +381,13 @@ class Environment(object):
         self._load_hosts_single_section(config)
         self._load_hosts_multi_section(config)
 
+        if self.ignore_hosts:
+            nonexistent = self.ignore_hosts.difference(set(self.hosts.keys()))
+            if nonexistent:
+                raise NonExistentIgnoredHostError.from_context(
+                    list(nonexistent)
+                )
+
         simplified_mapping = {
             k: v for k, v in self.hostname_mapping.items() if k != v
         }
@@ -378,7 +408,10 @@ class Environment(object):
                 self,
                 config={
                     "ignore": (
-                        "True" if literal_hostname.startswith("!") else "False"
+                        "True"
+                        if literal_hostname.startswith("!")
+                        or hostname in self.hosts
+                        else "False"
                     )
                 },
             )
@@ -393,7 +426,11 @@ class Environment(object):
                 continue
             hostname = section.replace("host:", "", 1)
 
-            host = self.host_factory(hostname, self, config[section])
+            config_section = config[section].copy()
+            if hostname in self.ignore_hosts:
+                config_section.update(ignore="True")
+
+            host = self.host_factory(hostname, self, config_section)
 
             # The name can now have been remapped.
             if host.name in self.hosts:

--- a/src/batou/main.py
+++ b/src/batou/main.py
@@ -92,6 +92,16 @@ def main(args: Optional[list] = None) -> None:
         "for operational flexibility.",
     )
     p.add_argument(
+        "-I",
+        "--ignore",
+        type=lambda arg: {x.strip() for x in arg.split(",")},
+        default=set(),
+        dest="ignore_hosts",
+        help="Comma-separated list of hosts to ignore. Equivalent to "
+        "the host setting ignore=True in the environment configuration "
+        "file.",
+    )
+    p.add_argument(
         "--provision-rebuild",
         action="store_true",
         help="Rebuild provisioned resources from scratch. "


### PR DESCRIPTION
This change adds a `-I` option to `batou deploy`, which allows specifying a comma separated list of hosts which should be ignored when deploying, as if the host had `ignore=True` in the environment configuration file.

I often run into situations where for operational reasons I'd like to roll out changes to the hosts in a given environment one at a time over several batou runs – the prime example being working on site routers, where inadvertent bad configs causing outages are a real risk. A CLI flag for this function avoids needing to repeatedly edit the environment file to adjust and swap around `ignore` settings.

Fixes #530.